### PR TITLE
feat: Add markmark for markdown->markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Markterm is a library and program to render Markdown to
 a terminal. It's inspired by [Glow](https://github.com/charmbracelet/glow)
 and implemented using [Markd](https://github.com/icyleaf/markd)
 
+It can also render Markdown to Markdown if you really need that :-)
+
 ## Features
 
 * It will syntax highlight code blocks
@@ -62,6 +64,8 @@ Options:
 If you use "-" as the file argument, markterm will read from stdin.
 ```
 
+There is a similar `markmark` binary that will render markdown to markdown.
+
 ## Usage as a library
 
 1. Add the dependency to your `shard.yml`:
@@ -76,6 +80,7 @@ In your code, use it like this:
 
 ```crystal
   puts Markd.to_term(source)
+  puts Markd.to_md(source)
 ```
 
 ## Contributing

--- a/shard.yml
+++ b/shard.yml
@@ -9,6 +9,8 @@ crystal: '>= 1.13.0'
 targets:
   markterm:
     main: src/main.cr
+  markmark:
+    main: src/main_mark.cr
 
 dependencies:
   markd:

--- a/src/main_mark.cr
+++ b/src/main_mark.cr
@@ -1,0 +1,41 @@
+require "./markmark"
+require "docopt"
+require "markd"
+
+doc = <<-DOC
+Markterm - A tool to render markdown to the terminal
+
+Usage:
+  markterm <file>
+  markterm -h | --help
+  markterm --version
+
+Options:
+  -h --help                  Show this screen.
+  --version                  Show version.
+
+If you use "-" as the file argument, markterm will read from stdin.
+DOC
+
+def main(source)
+  if source == "-"
+    input = STDIN.gets_to_end
+  else
+    input = File.read(source)
+  end
+  puts Markd.to_md(
+    input,
+  )
+end
+
+VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
+
+options = Docopt.docopt(doc, ARGV)
+if options["--version"]
+  puts "Markterm #{VERSION}"
+  exit 0
+end
+
+main(
+  options["<file>"].as(String),
+)


### PR DESCRIPTION
Adds a `to_mark` function and a `markmark` binary for markdown->markdown rendering.

See https://github.com/icyleaf/markd/issues/57 for info