### PR TITLE
Fix where value should be Char, not String

### DIFF
--- a/src/terminal.cr
+++ b/src/terminal.cr
@@ -66,7 +66,7 @@ module Terminal
     result = String::Builder.new
     STDIN.raw do |io|
       io.each_char do |chr|
-        break if chr == "\a" || chr == '\\'
+        break if chr == '\a' || chr == '\\'
         result << chr
       end
     end


### PR DESCRIPTION
Here's a simple test program:

```cr
require "markterm"

s = <<-TEXT
# Test
## Some markdown
TEXT

puts Markd.to_term(s)
```

When I run this in macOS Terminal, it hangs.

With some old-fashioned `puts` tracing 😄 found the bug in the `break` condition of the `Terminal#query_terminal(color)` method:

```cr
  def query_terminal(color) : String
    STDOUT << "\e]#{color};?\e\\"
    STDOUT.flush
    result = String::Builder.new
    STDIN.raw do |io|
      io.each_char do |chr|
        break if chr == "\a" || chr == '\\'         #<------------ Should be '\a' (Char) not "\a" (String)
        result << chr
      end
    end
    result.to_s
  end
```

@ralsina, it's a tiny fix, but it took an hour to find. 😁  
