### PR TITLE
fix: use CFLAGS when compiling C sources

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -76,7 +76,7 @@ build/litehtml/%.o: litehtml/src/%.cpp | build
 
 build/litehtml/%.o: litehtml/src/%.c | build
 	@mkdir -p $(dir $@)
-	$(CC) $(CXXFLAGS) $(INCLUDES) -I litehtml/src -c $< -o $@
+	$(CC) $(CFLAGS) $(INCLUDES) -I litehtml/src -c $< -o $@
 
 # The libtexprintf build generates two headers (errorflags.h,
 # errormessages.h) from error-marker comments in its sources; generate
@@ -92,7 +92,7 @@ build/libtexprintf/gen: $(wildcard $(TEXPRINTF_DIR)/src/gen_errorflags.sh) \
 
 build/libtexprintf/%.o: $(TEXPRINTF_DIR)/src/%.c | build build/libtexprintf/gen
 	@mkdir -p $(dir $@)
-	$(CC) $(CXXFLAGS) -I build/libtexprintf -I $(TEXPRINTF_DIR)/src -c $< -o $@
+	$(CC) $(CFLAGS) -I build/libtexprintf -I $(TEXPRINTF_DIR)/src -c $< -o $@
 
 build:
 	mkdir -p build


### PR DESCRIPTION
Hi!
When I tried building on macOS, Clang reported an error because `-std=c++17` was passed when compiling C sources.

This PR replaces `CXXFLAGS` with `CFLAGS` in the two Makefile rules that compile C sources. This is also consistent with the existing build rule for `litepdf_math.c`.

After this change, I confirmed that all four binaries build successfully on an Apple M2 running macOS Tahoe 26.6.2 with Crystal 1.21.0.
Thank you.