### PR TITLE
feat: adopt docopt-config 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ If you use "-" as the file argument, markterm will read from stdin.
 Options can also be set in ~/.config/markterm/config.yml (keys are the
 long option names, e.g. "theme: monokai") or through MARKTERM_*
 environment variables (e.g. MARKTERM_WIDTH). Command line options win
-over environment variables, which win over the config file.
+over environment variables, which win over the config file. Run with
+--print-config to dump the effective configuration as YAML.
 ```
 
 There is a similar `markmark` binary that will render markdown to markdown.
@@ -166,8 +167,31 @@ font:
   - LiberationSans.ttf
 ```
 
+Environment variables follow the same rules: booleans accept
+`true`/`yes`/`1` (and `false`/`no`/`0` to turn an option off), and
+repeatable options accept comma-separated lists
+(`MARKPDF_FONT=a.ttf,b.ttf`).
+
+Every tool also accepts a `--print-config` flag, which prints the
+effective configuration — command line, environment and config file
+merged — as YAML that can be saved and used as a config file as is:
+
+```console
+$ markpdf --print-config --style book
+---
+page_size: a4
+margin: "20"
+style: book
+language: en
+```
+
+`markterm` and `markmark` still require their file argument, so pass
+one (or `-` for stdin) when printing their configuration, e.g.
+`markterm --print-config - < document.md`.
+
 A missing config file is not an error; without one the tools behave
-exactly as they always have.
+exactly as they always have. A config file that exists but cannot be
+parsed produces a warning on stderr and is otherwise ignored.
 
 ### markpdf
 
@@ -194,13 +218,16 @@ Options:
   --version                  Show version.
   -o <output>, --output <output>  Write the PDF to a file (defaults to standard output)
   --page-size <size>         Page size: a0..a6, b0..b6, letter, legal, or
-                             custom WxH — values under 12 are
-                               inches (6x9 = 152.4x228.6mm) [default: a4]
+                             custom WxH — values under 12 are inches
+                             (6x9 = 152.4x228.6mm) [default: a4]
   --margin <margins>         Page margins in mm, CSS-style: 1 value (all sides),
                              2 (top/bottom, left/right), 4 (top, right, bottom,
                              left) or 5 (... plus gutter) [default: 20]
+  --mirror-headers           Mirror running headers and footers on verso
+                             (even) pages — pairs with a gutter margin
   --kdp                      KDP print mode: embed every font, drop the
-                             outline and scrub metadata
+                             outline, scrub metadata and pad odd page
+                             counts to even
   --style <style>            Built-in stylesheet setting layout and typography
                              (themes set colors instead): see --list-styles
                              [default: default]
@@ -242,6 +269,7 @@ long option names, e.g. "page-size: letter"; list-valued keys work for
 repeatable options, e.g. "font: [font1.ttf, font2.ttf]") or through
 MARKPDF_* environment variables (e.g. MARKPDF_STYLE). Command line
 options win over environment variables, which win over the config file.
+Run with --print-config to dump the effective configuration as YAML.
 ```
 
 #### Manual page breaks

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Options:
   --images                   Force images where the terminal can show them
   --no-images                Never draw images; show placeholders instead
   --no-pager                 Never pipe output to $PAGER
+  --config <path>            Read options from this YAML file instead of
+                             ~/.config/markterm/config.yml
 
 If you use "-" as the file argument, markterm will read from stdin.
 
@@ -188,6 +190,10 @@ language: en
 `markterm` and `markmark` still require their file argument, so pass
 one (or `-` for stdin) when printing their configuration, e.g.
 `markterm --print-config - < document.md`.
+
+Pass `--config <path>` to read the configuration from a specific file
+instead of the default one; the file must exist. The flag itself can
+only come from the command line.
 
 A missing config file is not an error; without one the tools behave
 exactly as they always have. A config file that exists but cannot be
@@ -258,6 +264,8 @@ Options:
   --no-remote-images         Skip http(s) image sources instead of fetching
                              them; remote fetching can also be turned off
                              programmatically with Markd::Pdf
+  --config <path>            Read options from this YAML file instead of
+                             ~/.config/markpdf/config.yml
 
 If you use "-" as the file argument, markpdf will read from stdin.
 Complete HTML documents (and .html files) are rendered directly,

--- a/shard.lock
+++ b/shard.lock
@@ -26,7 +26,7 @@ shards:
 
   docopt-config:
     git: https://github.com/ralsina/docopt-config.git
-    version: 0.2.0
+    version: 0.3.0
 
   exception_page:
     git: https://github.com/crystal-loot/exception_page.git

--- a/shard.yml
+++ b/shard.yml
@@ -36,7 +36,7 @@ dependencies:
   # CLI tools honor ~/.config/<tool>/config.yml and $TOOL_* env vars
   docopt-config:
     github: ralsina/docopt-config
-    version: ~> 0.2.0
+    version: ~> 0.3.0
   tartrazine:
     github: ralsina/tartrazine
   sixteen:

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -21,6 +21,46 @@ module Cli
     File.join(config_home, app_name, "config.yml")
   end
 
+  # Handle the --config <path> option: pull it out of argv (both the
+  # "--config path" and "--config=path" forms; tokens after "--" are
+  # positional and never options) and return the stripped argv plus the
+  # config file path to use: the one given, or the tool's XDG default.
+  # An explicitly given file must exist; a --config with no value is
+  # left in argv so docopt reports the missing argument.
+  def self.config_argv(app_name : String, argv : Array(String)) : {Array(String), String}
+    config_path : String? = nil
+    remaining = [] of String
+    index = 0
+    while index < argv.size
+      argument = argv[index]
+      if argument == "--"
+        remaining.concat(argv[index..])
+        break
+      elsif argument == "--config"
+        value = argv[index + 1]?
+        if value
+          config_path = value
+          index += 2
+        else
+          remaining << argument
+          index += 1
+        end
+      elsif argument.starts_with?("--config=")
+        config_path = argument["--config=".size..]
+        index += 1
+      else
+        remaining << argument
+        index += 1
+      end
+    end
+    if override = config_path
+      abort "#{app_name}: config file not found: #{override}" unless File.exists?(override)
+      {remaining, override}
+    else
+      {remaining, config_path(app_name)}
+    end
+  end
+
   # docopt-config returns config file values with their YAML types, so an
   # option documented as taking a string can come back as a number (e.g.
   # "margin: 20" as Int32, "margin: 20.5" as Float64, or a numeric docopt

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -22,13 +22,14 @@ module Cli
   end
 
   # docopt-config returns config file values with their YAML types, so an
-  # option documented as taking a string can come back as an Int32 (e.g.
-  # "margin: 20" or a numeric docopt default). Normalize those to the
-  # String docopt would have produced, ignoring values of other types.
+  # option documented as taking a string can come back as a number (e.g.
+  # "margin: 20" as Int32, "margin: 20.5" as Float64, or a numeric docopt
+  # default). Normalize those to the String docopt would have produced,
+  # ignoring values of other types.
   def self.option_string(value : Docopt::OptionValue?) : String?
     case value
-    when String then value
-    when Int32  then value.to_s
+    when String                then value
+    when Int32, Int64, Float64 then value.to_s
     end
   end
 
@@ -38,16 +39,11 @@ module Cli
     option_string(value) || fallback
   end
 
-  # Interpret an option as a boolean flag. docopt gives true for a flag
-  # given on the command line, false or nil otherwise; the config file
-  # can set true or false; environment variables are always strings, so
-  # "1", "true" or "yes" mean on, anything else off.
+  # Interpret an option as a boolean flag: true when the flag was given on
+  # the command line or set to true in the config file or environment
+  # (docopt-config coerces env var values), false or nil otherwise.
   def self.option_flag(value : Docopt::OptionValue?) : Bool
-    case value
-    when Bool   then value
-    when String then value == "1" || value.downcase == "true" || value.downcase == "yes"
-    else             false
-    end
+    value == true
   end
 
   # docopt returns a String when a repeatable option occurs once, and an

--- a/src/main.cr
+++ b/src/main.cr
@@ -33,7 +33,8 @@ doc = <<-DOC
   Options can also be set in ~/.config/markterm/config.yml (keys are the
   long option names, e.g. "theme: monokai") or through MARKTERM_*
   environment variables (e.g. MARKTERM_WIDTH). Command line options win
-  over environment variables, which win over the config file.
+  over environment variables, which win over the config file. Run with
+  --print-config to dump the effective configuration as YAML.
   DOC
 
 # Color: --color wins over everything; otherwise respect the
@@ -122,7 +123,8 @@ private def pipe_to_pager(text : String, pager : String)
 end
 
 options = Docopt.docopt_config(doc, argv: ARGV,
-  config_file_path: Cli.config_path("markterm"), env_prefix: "MARKTERM")
+  config_file_path: Cli.config_path("markterm"), env_prefix: "MARKTERM",
+  print_config_option: "--print-config")
 
 if options["--version"]
   puts "Markterm #{Cli::VERSION}"

--- a/src/main.cr
+++ b/src/main.cr
@@ -27,6 +27,8 @@ doc = <<-DOC
     --images                   Force images where the terminal can show them
     --no-images                Never draw images; show placeholders instead
     --no-pager                 Never pipe output to $PAGER
+    --config <path>            Read options from this YAML file instead of
+                               ~/.config/markterm/config.yml
 
   If you use "-" as the file argument, markterm will read from stdin.
 
@@ -122,8 +124,9 @@ private def pipe_to_pager(text : String, pager : String)
   end
 end
 
-options = Docopt.docopt_config(doc, argv: ARGV,
-  config_file_path: Cli.config_path("markterm"), env_prefix: "MARKTERM",
+argv, config_path = Cli.config_argv("markterm", ARGV)
+options = Docopt.docopt_config(doc, argv: argv,
+  config_file_path: config_path, env_prefix: "MARKTERM",
   print_config_option: "--print-config")
 
 if options["--version"]

--- a/src/main_mark.cr
+++ b/src/main_mark.cr
@@ -16,6 +16,11 @@ doc = <<-DOC
     --version                  Show version.
 
   If you use "-" as the file argument, markmark will read from stdin.
+
+  Options can also be set in ~/.config/markmark/config.yml or through
+  MARKMARK_* environment variables. Command line options win over
+  environment variables, which win over the config file. Run with
+  --print-config to dump the effective configuration as YAML.
   DOC
 
 def main(source)
@@ -26,7 +31,8 @@ def main(source)
 end
 
 options = Docopt.docopt_config(doc, argv: ARGV,
-  config_file_path: Cli.config_path("markmark"), env_prefix: "MARKMARK")
+  config_file_path: Cli.config_path("markmark"), env_prefix: "MARKMARK",
+  print_config_option: "--print-config")
 if options["--version"]
   puts "Markmark #{Cli::VERSION}"
   exit 0

--- a/src/main_mark.cr
+++ b/src/main_mark.cr
@@ -14,6 +14,8 @@ doc = <<-DOC
   Options:
     -h --help                  Show this screen.
     --version                  Show version.
+    --config <path>            Read options from this YAML file instead of
+                               ~/.config/markmark/config.yml
 
   If you use "-" as the file argument, markmark will read from stdin.
 
@@ -30,8 +32,9 @@ def main(source)
   puts Markd.to_md(input, options)
 end
 
-options = Docopt.docopt_config(doc, argv: ARGV,
-  config_file_path: Cli.config_path("markmark"), env_prefix: "MARKMARK",
+argv, config_path = Cli.config_argv("markmark", ARGV)
+options = Docopt.docopt_config(doc, argv: argv,
+  config_file_path: config_path, env_prefix: "MARKMARK",
   print_config_option: "--print-config")
 if options["--version"]
   puts "Markmark #{Cli::VERSION}"

--- a/src/main_pdf.cr
+++ b/src/main_pdf.cr
@@ -59,6 +59,8 @@ doc = <<-DOC
     --no-remote-images         Skip http(s) image sources instead of fetching
                                them; remote fetching can also be turned off
                                programmatically with Markd::Pdf
+    --config <path>            Read options from this YAML file instead of
+                               ~/.config/markpdf/config.yml
 
   If you use "-" as the file argument, markpdf will read from stdin.
   Complete HTML documents (and .html files) are rendered directly,
@@ -162,8 +164,9 @@ def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, h
   end
 end
 
-options = Docopt.docopt_config(doc, argv: ARGV,
-  config_file_path: Cli.config_path("markpdf"), env_prefix: "MARKPDF",
+argv, config_path = Cli.config_argv("markpdf", ARGV)
+options = Docopt.docopt_config(doc, argv: argv,
+  config_file_path: config_path, env_prefix: "MARKPDF",
   print_config_option: "--print-config")
 
 if options["--version"]

--- a/src/main_pdf.cr
+++ b/src/main_pdf.cr
@@ -70,6 +70,7 @@ doc = <<-DOC
   repeatable options, e.g. "font: [font1.ttf, font2.ttf]") or through
   MARKPDF_* environment variables (e.g. MARKPDF_STYLE). Command line
   options win over environment variables, which win over the config file.
+  Run with --print-config to dump the effective configuration as YAML.
   DOC
 
 def abort_with(message : String)
@@ -162,7 +163,8 @@ def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, h
 end
 
 options = Docopt.docopt_config(doc, argv: ARGV,
-  config_file_path: Cli.config_path("markpdf"), env_prefix: "MARKPDF")
+  config_file_path: Cli.config_path("markpdf"), env_prefix: "MARKPDF",
+  print_config_option: "--print-config")
 
 if options["--version"]
   puts "Markpdf #{Cli::VERSION}"


### PR DESCRIPTION
Adopts [docopt-config](https://github.com/ralsina/docopt-config) v0.3.0 in all three CLIs (`markterm`, `markmark`, `markpdf`), which shipped several improvements since the v0.2.0 integration.

## What we gain

- **`--print-config`** (all three CLIs): dumps the fully-resolved configuration — CLI arguments, environment variables, config file and docopt defaults merged — as YAML that can be saved and used as a config file as is:
  ```console
  $ markpdf --print-config --style book
  ---
  page_size: a4
  margin: "20"
  style: book
  language: en
  ```
  `markterm`/`markmark` still require their file argument, so use e.g. `markterm --print-config - < document.md`.
- **Environment variable type coercion**: `MARKTERM_HYPHENATE=1` is now a real boolean, and repeatable options accept comma-separated lists (`MARKPDF_FONT=a.ttf,b.ttf`).
- **Better failure modes**: invalid arguments print the message and usage to stderr and exit 1 (v0.2.0 printed the doc and exited 0); a config file that exists but cannot be parsed produces a warning on stderr instead of being silently ignored. Missing config files remain silent.

## Adaptation required by this PR

v0.3.0 preserves config-file floats and large integers as `Float64`/`Int64` instead of stringifying them. `Cli.option_string` now handles all numeric types, so `margin: 20.5` keeps working instead of being dropped. `Cli.option_flag` shrank to `value == true` since the library now coerces env values itself.

## Verification

- `shards build`: all four binaries build
- `crystal spec`: 231 examples, 0 failures
- `ameba`: 0 failures
- README help blocks verified identical to the actual `--help` output
- Smoke-tested: precedence (CLI > env > config > defaults), env bool coercion, env comma-split font lists, fractional margins, broken-config warning, usage-error exit codes, and the `--print-config` roundtrip (dump → save as config.yml → same effective configuration)