### PR TITLE
feat: two-pass table of contents with linked, numbered entries

### DIFF
--- a/KDP.md
+++ b/KDP.md
@@ -45,6 +45,13 @@ footer and no content, the way a real book's blanks look. They do count
 toward the page number and the `%t` total, because in print they count,
 period.
 
+A `--toc` table of contents plays by those same rules: its pages are
+ordinary pages — they count toward the page number, the recto fillers
+and the even-page pad — and the entry numbers are settled by
+re-rendering until the TOC matches the real layout, blanks included.
+So `# Chapter 1` after a one-page TOC lands on page 3, and the TOC
+says 3.
+
 If you pass your own gutter in `--margin` (the five-value form below),
 markpdf respects it and skips the table lookup.
 
@@ -166,9 +173,6 @@ additions do not apply there — add the rules yourself.
 - **Front matter.** Title page, copyright page, dedication — that is
   content. (A `# Title` heading opens on page 1, which is recto by
   definition, so the recto rule does not push it anywhere.)
-- **A table of contents with page numbers.** The tool has no two-pass
-  TOC; write it by hand after the layout settles, or skip a TOC — KDP
-  does not require one in print.
 - **Bleed.** Text-and-figures interiors do not need it; if you want
   edge-to-edge images, markpdf is the wrong tool for that page. Keep
   images inside the margins and the no-bleed rules cover you.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Done recently (markpdf):
   `--print-style` and repeatable `--css`
 * ✅ Pageless single-page output (`--pageless`)
 * ✅ PDF outline bookmarks from headings
+* ✅ Two-pass table of contents (`--toc`) with linked, numbered entries
 * ✅ Task-list checkboxes (☑/☐)
 * ✅ Wide tables scale to fit and split across pages at row boundaries
 * ✅ Collapse-style table borders and keep-with-next pagination
@@ -240,6 +241,13 @@ Options:
   --no-remote-images         Skip http(s) image sources instead of fetching
                              them; remote fetching can also be turned off
                              programmatically with Markd::Pdf
+  --toc                      Prepend a table of contents with page numbers;
+                             every entry links to its section. The layout
+                             runs repeatedly until the numbers stop moving
+                             (a TOC's own length shifts the pages it points to)
+  --toc-depth <depth>        Deepest heading level the TOC lists, from
+                             1 (chapters only) to 6 [default: 1]
+  --toc-title <title>        Title above the table of contents [default: Contents]
 
 If you use "-" as the file argument, markpdf will read from stdin.
 Complete HTML documents (and .html files) are rendered directly,
@@ -278,6 +286,27 @@ work the same way. Named pages work too: `page-break-before: right`
 inserting a blank page when it would otherwise land on a wrong-parity
 one — the classic convention that chapters start on odd pages. Blank
 filler pages carry no content and no header or footer.
+
+#### Table of contents
+
+`--toc` prepends a linked table of contents with page numbers. Because
+the TOC's own length shifts every page after it, the numbers are found
+by fixed point: markpdf renders, reads back where each heading landed,
+rebuilds the TOC, and re-renders until what the TOC says matches where
+things are — two or three passes for a typical book. Entries link to
+their sections in the PDF.
+
+```bash
+markpdf book.md --toc --toc-depth 2 --toc-title "Inhalt" --kdp -o book.pdf
+```
+
+`--toc-depth` caps how deep the listing goes (1 = chapters only, up to
+6); `--toc-title` sets the heading above it. TOC pages are ordinary
+pages: they count toward the page count, the kdp recto rule and the
+even-page pad, and the TOC's numbers account for all of it. With
+`--pageless` the entries lose their page numbers (there are no pages),
+and `--toc` on a document without headings warns and renders without
+the TOC.
 
 #### Styles
 

--- a/ext/litepdf.cpp
+++ b/ext/litepdf.cpp
@@ -2736,12 +2736,70 @@ int litepdf_set_emoji_font(const char* ttf_path, char* errbuf, int errbuf_len)
 // pages, right on even ones; negative disables it). kdp mode embeds
 // every font, drops the outline and scrubs metadata. Returns the number of pages, or -1 and fills
 // errbuf on failure.
+// One page's flow-space Y range; blank filler pages draw no content.
+// File scope so the heading-page helper can share it with render_pdf.
+struct PageWindow
+{
+    float first;
+    float second;
+    bool blank;
+};
+
+// The page whose window covers a flow-space Y coordinate, or -1.
+static int page_index_for_flow(const std::vector<PageWindow>& windows, float flow_y)
+{
+    for (size_t i = 0; i < windows.size(); i++)
+    {
+        if (flow_y >= windows[i].first && flow_y < windows[i].second)
+        {
+            return (int)i;
+        }
+    }
+    return -1;
+}
+
+// Runs of whitespace collapse to single spaces: heading titles feed
+// both the PDF outline and the two-pass TOC map, where they must be
+// single-line and free of the map's tab separator.
+static std::string collapse_spaces(const std::string& text)
+{
+    std::string collapsed;
+    bool previous_space = true;
+    for (char character : text)
+    {
+        if (std::isspace((unsigned char)character))
+        {
+            if (!previous_space)
+            {
+                collapsed += ' ';
+            }
+            previous_space = true;
+        }
+        else
+        {
+            collapsed += character;
+            previous_space = false;
+        }
+    }
+    while (!collapsed.empty() && collapsed.back() == ' ')
+    {
+        collapsed.pop_back();
+    }
+    return collapsed;
+}
+
 static int render_pdf(const char* html, const char* css, float page_width_mm, float page_height_mm,
                float margin_top, float margin_right, float margin_bottom, float margin_left,
                float margin_gutter, const char* base_dir, const char* header, const char* footer,
                const char* page_background, char* errbuf, int errbuf_len, int single_page, int kdp,
-               int mirror_headers, char** out_data, size_t* out_len)
+               int mirror_headers, char** out_data, size_t* out_len,
+               char** heading_map, size_t* heading_map_len)
 {
+    if (heading_map && heading_map_len)
+    {
+        *heading_map = nullptr;
+        *heading_map_len = 0;
+    }
     if (errbuf && errbuf_len > 0)
     {
         errbuf[0] = '\0';
@@ -3036,12 +3094,6 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
     // One page per window: the flow-space Y range it shows, plus a
     // blank flag. Filler pages — named-page chapter starts and the kdp
     // parity pad — draw no content and carry no header or footer.
-    struct PageWindow
-    {
-        float first;
-        float second;
-        bool blank;
-    };
     std::vector<PageWindow> windows;
     if (single_page)
     {
@@ -3482,48 +3534,19 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
         g_last_op = "creating outline";
         for (const auto& heading : container.headings)
         {
-    int page_idx = -1;
     // Headings are collected in document space; windows live in flow
     // space (wide tables compressed). Map before matching, exactly like
     // the link and anchor paths, and keep the page-relative offset for
     // the destination.
     float heading_flow = container.flow_y(heading.y);
-    for (size_t i = 0; i < windows.size(); i++)
-    {
-        if (heading_flow >= windows[i].first && heading_flow < windows[i].second)
-        {
-            page_idx = (int)i;
-            heading_flow -= windows[i].first;
-            break;
-        }
-    }
+    int page_idx = page_index_for_flow(windows, heading_flow);
     if (page_idx < 0)
     {
         continue;
     }
+    heading_flow -= windows[page_idx].first;
 
-    std::string title;
-    bool previous_space = true;
-    for (char character : heading.title)
-    {
-        if (std::isspace((unsigned char)character))
-        {
-            if (!previous_space)
-            {
-                title += ' ';
-            }
-            previous_space = true;
-        }
-        else
-        {
-            title += character;
-            previous_space = false;
-        }
-    }
-    while (!title.empty() && title.back() == ' ')
-    {
-        title.pop_back();
-    }
+    std::string title = collapse_spaces(heading.title);
     if (title.empty())
     {
         continue;
@@ -3557,6 +3580,46 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
                 {
                     level_stack[lvl] = nullptr;
                 }
+            }
+        }
+    }
+
+    // Heading -> page map for the two-pass table of contents: one
+    // "index\tlevel\tpage\ttitle" line per heading in document order,
+    // pages 1-based (0 = heading fell on no page window). The index
+    // counts headings with visible text, matching the anchor ids the
+    // Crystal side injects into the HTML. Collected in every mode —
+    // unlike the outline, which kdp drops — because the TOC needs it
+    // there too.
+    if (heading_map && heading_map_len)
+    {
+        std::string map;
+        int heading_index = 0;
+        for (const auto& heading : container.headings)
+        {
+            std::string title = collapse_spaces(heading.title);
+            if (title.empty())
+            {
+                continue;
+            }
+            heading_index++;
+            int page_idx = page_index_for_flow(windows, container.flow_y(heading.y));
+            map += std::to_string(heading_index);
+            map += '\t';
+            map += std::to_string(heading.level);
+            map += '\t';
+            map += std::to_string(page_idx + 1);
+            map += '\t';
+            map += title;
+            map += '\n';
+        }
+        if (!map.empty())
+        {
+            if (char* buffer = (char*)std::malloc(map.size() + 1))
+            {
+                std::memcpy(buffer, map.c_str(), map.size() + 1);
+                *heading_map = buffer;
+                *heading_map_len = map.size();
             }
         }
     }
@@ -3596,18 +3659,21 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
 }
 
 // Render to a malloc'd buffer the caller frees with litepdf_free_buffer.
+// heading_map receives the heading->page map for the two-pass TOC (also
+// malloc'd, also freed by litepdf_free_buffer); it may stay null when
+// the document has no headings.
 int litepdf_render_to_memory(const char* html, const char* css, float page_width_mm,
                              float page_height_mm, float margin_top, float margin_right,
                              float margin_bottom, float margin_left, float margin_gutter,
                              const char* base_dir, const char* header, const char* footer,
                              const char* page_background, char* errbuf, int errbuf_len,
                              int single_page, int kdp, int mirror_headers, char** out_data,
-                             size_t* out_len)
+                             size_t* out_len, char** heading_map, size_t* heading_map_len)
 {
     return render_pdf(html, css, page_width_mm, page_height_mm, margin_top, margin_right,
                       margin_bottom, margin_left, margin_gutter, base_dir, header, footer,
                       page_background, errbuf, errbuf_len, single_page, kdp, mirror_headers,
-                      out_data, out_len);
+                      out_data, out_len, heading_map, heading_map_len);
 }
 
 void litepdf_free_buffer(char* buffer)
@@ -3622,14 +3688,15 @@ int litepdf_render(const char* html, const char* css, float page_width_mm, float
                    float margin_gutter, const char* out_path,
                    const char* base_dir, const char* header, const char* footer,
                    const char* page_background, char* errbuf, int errbuf_len, int single_page, int kdp,
-                   int mirror_headers)
+                   int mirror_headers, char** heading_map, size_t* heading_map_len)
 {
     char* data = nullptr;
     size_t len = 0;
     int pages = litepdf_render_to_memory(html, css, page_width_mm, page_height_mm, margin_top,
                                          margin_right, margin_bottom, margin_left, margin_gutter,
                                          base_dir, header, footer, page_background, errbuf,
-                                         errbuf_len, single_page, kdp, mirror_headers, &data, &len);
+                                         errbuf_len, single_page, kdp, mirror_headers, &data, &len,
+                                         heading_map, heading_map_len);
     if (pages < 0)
     {
         return pages;

--- a/spec/pdf_toc_spec.cr
+++ b/spec/pdf_toc_spec.cr
@@ -1,0 +1,273 @@
+require "./spec_helper"
+
+# The two-pass table of contents.
+#
+# A TOC's page numbers depend on the layout, and the layout depends on
+# the TOC — its own length shifts every page after it — so the numbers
+# only exist as a fixed point: render, read the heading map the shim
+# collected, rebuild the TOC from it, render again. These specs cover
+# the pieces (map parsing, anchor numbering, block building), the map
+# the layout produces, and the end-to-end contract: every number the
+# TOC shows is the page where that heading actually rendered.
+
+private def temp_pdf_path : String
+  File.tempname("markpdf_spec_toc", ".pdf")
+end
+
+private def pdftotext_path : String?
+  Process.find_executable("pdftotext")
+end
+
+private def page_text(pdftotext : String, pdf_path : String, page : Int32) : String
+  output = IO::Memory.new
+  Process.run(pdftotext, ["-f", page.to_s, "-l", page.to_s, "-layout", pdf_path, "-"],
+    output: output, error: IO::Memory.new)
+  output.to_s
+end
+
+private def all_page_texts(pdftotext : String, pdf_path : String, pages : Int32) : Array(String)
+  (1..pages).map { |page| page_text(pdftotext, pdf_path, page) }
+end
+
+# The page whose extracted text contains the token as a standalone
+# line (so a TOC entry "Beta" does not match the chapter heading "Beta",
+# both of which appear in the document).
+private def pages_with_line(page_texts : Array(String), token : String) : Array(Int32)
+  pages = [] of Int32
+  page_texts.each_with_index do |text, index|
+    pages << index + 1 if text.lines.includes?(token)
+  end
+  pages
+end
+
+private def toc_entries
+  [
+    Markd::Pdf::HeadingEntry.new(1, 1, 2, "Alpha"),
+    Markd::Pdf::HeadingEntry.new(2, 2, 2, "Alpha.1"),
+    Markd::Pdf::HeadingEntry.new(3, 1, 5, "Beta"),
+    Markd::Pdf::HeadingEntry.new(4, 1, 0, "Nowhere"),
+  ]
+end
+
+describe "Markd::Pdf.parse_heading_map" do
+  it "parses index, level, page and title from the shim's map lines" do
+    headings = Markd::Pdf.parse_heading_map("1\t1\t3\tAlpha\n2\t2\t4\tBeta  section")
+    headings.size.should eq(2)
+    headings[0].index.should eq(1)
+    headings[0].level.should eq(1)
+    headings[0].page.should eq(3)
+    headings[0].title.should eq("Alpha")
+    headings[1].title.should eq("Beta  section")
+  end
+
+  it "strips soft hyphens from titles" do
+    headings = Markd::Pdf.parse_heading_map("1\t1\t1\thy\u{00AD}phen\u{00AD}ated")
+    headings[0].title.should eq("hyphenated")
+  end
+
+  it "returns an empty list for an empty map" do
+    Markd::Pdf.parse_heading_map("").should be_empty
+  end
+end
+
+describe "Markd::Pdf.rewrite_heading_anchors" do
+  it "numbers headings in document order and preserves their content" do
+    html = "<h1>One</h1><h2>Two</h2><h1>Three</h1>"
+    anchored = Markd::Pdf.rewrite_heading_anchors(html)
+    anchored.should eq(
+      "<h1><a id=\"mtoc-1\"></a>One</h1>" +
+      "<h2><a id=\"mtoc-2\"></a>Two</h2>" +
+      "<h1><a id=\"mtoc-3\"></a>Three</h1>")
+  end
+
+  it "keeps heading text intact, including inline markup and entities" do
+    html = "<h1>A <em>bold</em> &amp; long title</h1>"
+    anchored = Markd::Pdf.rewrite_heading_anchors(html)
+    anchored.should eq("<h1><a id=\"mtoc-1\"></a>A <em>bold</em> &amp; long title</h1>")
+  end
+
+  it "does not number headings without visible text, keeping the map aligned" do
+    html = "<h1>First</h1><h1>   </h1><h1><span></span></h1><h1>Second</h1>"
+    anchored = Markd::Pdf.rewrite_heading_anchors(html)
+    anchored.should contain("<h1>   </h1>")
+    anchored.should contain("<h1><span></span></h1>")
+    anchored.should contain("<a id=\"mtoc-1\"></a>First")
+    anchored.should contain("<a id=\"mtoc-2\"></a>Second")
+  end
+end
+
+describe "Markd::Pdf.toc_html" do
+  it "lists entries with links, page numbers and level indents" do
+    block = Markd::Pdf.toc_html(toc_entries, 2, "Contents", false).should_not be_nil
+    block.should contain("<div class=\"toc-title\">Contents</div>")
+    block.should contain("<a href=\"#mtoc-1\"><span class=\"toc-text\">Alpha</span>" +
+                         "<span class=\"toc-page\">2</span></a>")
+    block.should contain("toc-level-2")
+    block.should contain("<a href=\"#mtoc-3\"><span class=\"toc-text\">Beta</span>" +
+                         "<span class=\"toc-page\">5</span></a>")
+  end
+
+  it "filters by depth and drops headings that fell on no page" do
+    block = Markd::Pdf.toc_html(toc_entries, 1, "Contents", false).should_not be_nil
+    block.should_not contain("Alpha.1")
+    block.should_not contain("Nowhere")
+  end
+
+  it "omits page numbers in pageless mode" do
+    block = Markd::Pdf.toc_html(toc_entries, 2, "Contents", true).should_not be_nil
+    block.should contain("Alpha")
+    block.should_not contain("toc-page")
+  end
+
+  it "escapes the title and entry text" do
+    headings = [Markd::Pdf::HeadingEntry.new(1, 1, 1, "A < B & \"C\"")]
+    block = Markd::Pdf.toc_html(headings, 1, "T & T", false).should_not be_nil
+    block.should contain("T &amp; T")
+    block.should contain("A &lt; B &amp; &quot;C&quot;")
+  end
+
+  it "is nil when no heading survives the filters" do
+    Markd::Pdf.toc_html([] of Markd::Pdf::HeadingEntry, 3, "Contents", false).should be_nil
+    only_nowhere = [Markd::Pdf::HeadingEntry.new(1, 1, 0, "Nowhere")]
+    Markd::Pdf.toc_html(only_nowhere, 1, "Contents", false).should be_nil
+  end
+end
+
+describe "Markd::Pdf::Renderer#render_with_headings" do
+  renderer = Markd::Pdf::Renderer.new(page_size: "a4")
+
+  it "returns the heading map of a known layout" do
+    source = <<-MD
+      # First
+
+      #{("word " * 900).strip}
+
+      # Second
+
+      #{("word " * 900).strip}
+
+      # Third
+      MD
+    pages, headings = renderer.render_with_headings(source, temp_pdf_path)
+    pages.should be >= 2
+    headings.map(&.title).should eq(["First", "Second", "Third"])
+    headings.map(&.level).should eq([1, 1, 1])
+    headings.map(&.index).should eq([1, 2, 3])
+    headings[0].page.should eq(1)
+    headings[2].page.should eq(pages)
+  end
+
+  it "renders the TOC block ahead of the body and links entries to anchors" do
+    headings = [
+      Markd::Pdf::HeadingEntry.new(1, 1, 1, "Solo"),
+    ]
+    toc = Markd::Pdf.toc_html(headings, 1, "Contents", false)
+    pages, mapped = renderer.render_with_headings("# Solo\n\nBody text.", temp_pdf_path, toc)
+    pages.should eq(2) # the TOC page, then the body
+    mapped.map(&.title).should eq(["Solo"])
+    mapped[0].page.should eq(2)
+  end
+end
+
+describe "markpdf two-pass TOC" do
+  it "shows every chapter at the page where it actually rendered" do
+    pdftotext = pdftotext_path
+    pending!("pdftotext not available") unless pdftotext
+
+    chapters = 12
+    source = String.build do |io|
+      1.upto(chapters) do |chapter|
+        io << "# Chaptertoken" << chapter << "\n\n"
+        5.times { |run| io << "Filler " << (chapter * 10 + run) << " " << ("prose " * 40).strip << "\n\n" }
+      end
+    end
+
+    path = temp_pdf_path
+    pages = Markd::Pdf.render(source, path, toc: true)
+    texts = all_page_texts(pdftotext, path, pages)
+
+    # The TOC page lists each chapter next to the number of the page
+    # whose text contains that chapter's heading — and the heading
+    # lines appear exactly once each (a TOC entry line carries a page
+    # number, so it never equals the bare heading token).
+    toc_page = texts.index(&.includes?("Contents")).should_not be_nil
+    toc_text = texts[toc_page]
+    1.upto(chapters) do |chapter|
+      token = "Chaptertoken#{chapter}"
+      number = toc_text.scan(/#{token}\s+(\d+)/).first?.try(&.[1])
+      number.should_not be_nil, "no TOC entry for #{token}"
+      landing = pages_with_line(texts, token)
+      landing.size.should eq(1), "#{token} heading appears on pages #{landing}"
+      landing[0].to_s.should eq(number), "TOC says #{token} is on page #{number}, it renders on #{landing[0]}"
+    end
+    File.delete?(path)
+  end
+
+  it "keeps numbers correct in kdp mode, where chapters open on recto pages" do
+    pdftotext = pdftotext_path
+    pending!("pdftotext not available") unless pdftotext
+
+    source = "# One\n\nprose one\n\n# Two\n\nprose two\n\n# Three\n\nprose three\n"
+    path = temp_pdf_path
+    pages = Markd::Pdf.render(source, path, margins: "20,20,20,20,15", kdp: true, toc: true)
+    pages.should be > 3
+
+    texts = all_page_texts(pdftotext, path, pages)
+    toc_page = texts.index(&.includes?("Contents")).should_not be_nil
+    toc_text = texts[toc_page]
+
+    ["One", "Two", "Three"].each do |chapter|
+      number = toc_text.scan(/#{chapter}\s+(\d+)/).first?.try(&.[1])
+      number.should_not be_nil, "no TOC entry for #{chapter}"
+      landing = pages_with_line(texts, chapter)
+      landing.size.should eq(1), "chapter #{chapter} on pages #{landing}"
+      landing[0].to_s.should eq(number), "TOC says #{chapter} is on page #{number}, it renders on #{landing[0]}"
+      # kdp chapters open on recto (odd) pages, blanks included.
+      landing[0].odd?.should be_true
+    end
+    File.delete?(path)
+  end
+
+  it "renders without page numbers in pageless mode" do
+    pdftotext = pdftotext_path
+    pending!("pdftotext not available") unless pdftotext
+
+    source = "# One\n\nprose one\n\n# Two\n\nprose two\n"
+    path = temp_pdf_path
+    Markd::Pdf.render(source, path, pageless: true, toc: true)
+    text = page_text(pdftotext, path, 1)
+    text.should contain("Contents")
+    text.should contain("One")
+    text.should_not match(/One\s+\d+/)
+    File.delete?(path)
+  end
+end
+
+describe "markpdf CLI --toc" do
+  it "renders a TOC and errors on a bad depth" do
+    pending!("bin/markpdf not built") unless File.exists?(BIN_MARKPDF)
+
+    source = File.tempname("markpdf_spec_toc", ".md")
+    File.write(source, "# Alpha\n\nprose\n\n# Beta\n\nprose\n")
+    output = temp_pdf_path
+    status = Process.run(BIN_MARKPDF, [source, "--toc", "-o", output],
+      error: Process::Redirect::Inherit).success?
+    status.should be_true
+    File.exists?(output).should be_true
+
+    pdftotext = pdftotext_path
+    if pdftotext
+      first = page_text(pdftotext, output, 1)
+      first.should contain("Contents")
+      first.should contain("Alpha")
+    end
+    File.delete?(output)
+
+    bad = temp_pdf_path
+    result = Process.run(BIN_MARKPDF, [source, "--toc", "--toc-depth", "9", "-o", bad],
+      output: IO::Memory.new, error: IO::Memory.new)
+    result.success?.should be_false
+    File.exists?(bad).should be_false
+    File.delete?(source)
+  end
+end

--- a/src/main_pdf.cr
+++ b/src/main_pdf.cr
@@ -61,6 +61,13 @@ doc = <<-DOC
     --no-remote-images         Skip http(s) image sources instead of fetching
                                them; remote fetching can also be turned off
                                programmatically with Markd::Pdf
+    --toc                      Prepend a table of contents with page numbers;
+                               every entry links to its section. The layout
+                               runs repeatedly until the numbers stop moving
+                               (a TOC's own length shifts the pages it points to)
+    --toc-depth <depth>        Deepest heading level the TOC lists, from
+                               1 (chapters only) to 6 [default: 1]
+    --toc-title <title>        Title above the table of contents [default: Contents]
 
   If you use "-" as the file argument, markpdf will read from stdin.
   Complete HTML documents (and .html files) are rendered directly,
@@ -129,32 +136,41 @@ rescue error : Markd::Pdf::Error
   abort_with(error.message.to_s)
 end
 
-# The gutter feeds back into the page count: size it from the first
-# pass and re-render when the table asks for a different one.
-def render_kdp_guttered(input, output, pages, margin, css_bodies, options, style, theme, code_theme, page_size, mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate, language)
-  gutter = Markd::Pdf.kdp_gutter_mm(pages)
-  parsed = Markd::Pdf.parse_margins(margin)
-  if parsed.gutter < 0 && gutter != parsed.gutter
-    guttered = Markd::Pdf.margins_with_gutter(parsed, gutter)
-    renderer = build_renderer(options, style, theme, code_theme, page_size, guttered, true,
-      mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate, language)
-    css_bodies.each do |css_body|
-      renderer.add_css(css_body)
-    end
-    pages = renderer.render(input, output)
-  end
-  margin_warning = Markd::Pdf.kdp_margin_warning(parsed)
-  STDERR.puts "markpdf: warning: #{margin_warning}" if margin_warning
-  page_warning = Markd::Pdf.kdp_range_warning(pages)
-  STDERR.puts "markpdf: warning: #{page_warning}" if page_warning
-  pages
+# The kdp gutter sizing, the TOC page numbers and the kdp warnings all
+# come from the library's settle loop; the CLI only picks where the
+# PDF lands and which code theme applies.
+def render_kdp(input, output, margin, options, style, theme, code_theme, page_size, mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate, language, toc, toc_depth, toc_title)
+  Markd::Pdf.render(input, output, options, page_size: page_size, base_dir: base_dir,
+    header: header || "", footer: footer || "", theme: theme, html_input: html_input, style: style,
+    pageless: pageless, hyphenate: hyphenate, language: language,
+    code_theme: Markd::Pdf.pick_code_theme(code_theme, theme, style),
+    margins: margin, kdp: true, mirror_headers: mirror_headers,
+    toc: toc, toc_depth: toc_depth, toc_title: toc_title)
 end
 
-def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, header, footer, theme, code_theme, style, html_input, pageless, hyphenate, language, no_remote_images, kdp, mirror_headers)
+# Non-kdp TOC renders go through the same settle loop, against the
+# renderer the CLI already built (margins are fixed without the gutter
+# table, so one instance serves every pass).
+def render_toc(input, output, renderer, toc_depth, toc_title, pageless)
+  Markd::Pdf.settled_pages(true, toc_depth, toc_title, pageless, size_gutter: false) do |_, desired_toc|
+    renderer.render_with_headings(input, output, desired_toc)
+  end
+end
+
+# --toc-depth: an integer between 1 and 6, or the run stops here.
+def toc_depth_from(depth_string : String) : Int32
+  depth = depth_string.to_i?
+  return depth if depth && depth.in?(1..6)
+  abort_with("--toc-depth needs an integer between 1 and 6 (got '#{depth_string}')")
+end
+
+def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, header, footer, theme, code_theme, style, html_input, pageless, hyphenate, language, no_remote_images, kdp, mirror_headers, toc, toc_depth_string, toc_title)
   input = Cli.read_source(source)
   base_dir = source == "-" ? "." : File.dirname(File.expand_path(source))
 
   Markd::Pdf.fetch_remote_images = !no_remote_images
+
+  toc_depth = toc_depth_from(toc_depth_string)
 
   if kdp && font_paths.empty?
     STDERR.puts "markpdf: warning: no --font given; kdp mode embeds whatever system fonts cover the text. Pass --font to control the embedded typefaces."
@@ -177,24 +193,23 @@ def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, h
   setup_emoji_font(emoji_font) if emoji_font
   register_fonts(font_paths)
 
-  if output
-    pages = renderer.render(input, output)
+  # No output file: render to a temporary file and stream to stdout.
+  target = output || File.tempname("markpdf", ".pdf")
+  begin
     if kdp
-      # The re-render and range warning happen inside; the final count
-      # is not needed here.
-      render_kdp_guttered(input, output, pages, margin, css_bodies, options,
-        style, theme, code_theme, page_size, mirror_headers, base_dir, header, footer,
-        html_input, pageless, hyphenate, language)
+      render_kdp(input, target, margin, options, style, theme, code_theme, page_size,
+        mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate,
+        language, toc, toc_depth, toc_title)
+    elsif toc
+      render_toc(input, target, renderer, toc_depth, toc_title, pageless)
+    else
+      renderer.render(input, target)
     end
-  else
-    # No output file: render to a temporary file and stream to stdout
-    temp_path = File.tempname("markpdf", ".pdf")
-    begin
-      renderer.render(input, temp_path)
-      STDOUT.write(File.read(temp_path).to_slice)
-    ensure
-      File.delete?(temp_path)
+    unless output
+      STDOUT.write(File.read(target).to_slice)
     end
+  ensure
+    File.delete?(target) unless output
   end
 end
 
@@ -245,6 +260,9 @@ begin
     Cli.option_flag(options["--no-remote-images"]),
     Cli.option_flag(options["--kdp"]),
     Cli.option_flag(options["--mirror-headers"]),
+    Cli.option_flag(options["--toc"]),
+    Cli.option_string(options["--toc-depth"], "1"),
+    Cli.option_string(options["--toc-title"], "Contents"),
   )
 rescue error
   abort_with(error.message.to_s)

--- a/src/pdf.cr
+++ b/src/pdf.cr
@@ -6,6 +6,7 @@ require "tartrazine/formatters/html"
 require "markd"
 require "sixteen"
 require "crimage"
+require "html"
 require "http/client"
 require "uri"
 require "base64"
@@ -38,7 +39,8 @@ lib Litepdf
                               out_path : LibC::Char*, base_dir : LibC::Char*, header : LibC::Char*,
                               footer : LibC::Char*, page_background : LibC::Char*, errbuf : LibC::Char*,
                               errbuf_len : LibC::Int, single_page : LibC::Int, kdp : LibC::Int,
-                              mirror_headers : LibC::Int) : LibC::Int
+                              mirror_headers : LibC::Int, heading_map : LibC::Char**,
+                              heading_map_len : LibC::SizeT*) : LibC::Int
   fun render_to_memory = litepdf_render_to_memory(html : LibC::Char*, css : LibC::Char*,
                                                   page_width_mm : LibC::Float, page_height_mm : LibC::Float,
                                                   margin_top : LibC::Float, margin_right : LibC::Float,
@@ -48,7 +50,9 @@ lib Litepdf
                                                   page_background : LibC::Char*, errbuf : LibC::Char*,
                                                   errbuf_len : LibC::Int, single_page : LibC::Int, kdp : LibC::Int,
                                                   mirror_headers : LibC::Int,
-                                                  out_data : LibC::Char**, out_len : LibC::SizeT*) : LibC::Int
+                                                  out_data : LibC::Char**, out_len : LibC::SizeT*,
+                                                  heading_map : LibC::Char**,
+                                                  heading_map_len : LibC::SizeT*) : LibC::Int
   fun free_buffer = litepdf_free_buffer(buffer : LibC::Char*)
   fun register_font = litepdf_register_font(ttf_path : LibC::Char*, errbuf : LibC::Char*,
                                             errbuf_len : LibC::Int) : LibC::Int
@@ -269,6 +273,56 @@ module Markd
       raise Error.new("could not load theme '#{name}': #{error.message}")
     end
 
+    # Renders until the TOC page numbers (and, when sizing the kdp
+    # gutter, the gutter) stop moving: each pass lays out the document
+    # with the current TOC block, then rebuilds that block from where
+    # the headings actually landed — the TOC's own length shifts every
+    # page after it, so one pass can never know its numbers. Two or
+    # three passes converge; the cap is a safety net for pathological
+    # documents. Yields the gutter to use this pass (-1 when the caller
+    # sizes margins itself) and the TOC block to render with (nil =
+    # none), and returns the final page count. Internal, but shared
+    # with the CLI, which owns its Renderer construction.
+    MAX_TOC_PASSES = 6
+
+    # The one-time warning for a --toc that has nothing to list: either
+    # the document has no headings, or none survive the depth filter.
+    private def self.warn_missing_toc(headings : Array(HeadingEntry), toc_depth : Int32) : Nil
+      if headings.empty?
+        STDERR.puts "markpdf: warning: --toc found no headings; rendering without a table of contents"
+      else
+        STDERR.puts "markpdf: warning: --toc found no headings at depth #{toc_depth}; rendering without a table of contents"
+      end
+    end
+
+    def self.settled_pages(toc : Bool, toc_depth : Int32, toc_title : String, pageless : Bool,
+                           size_gutter : Bool, &pass : Float64, String? -> {Int32, Array(HeadingEntry)}) : Int32
+      gutter = KDP_GUTTER_TABLE.first[2]
+      desired_toc = nil.as(String?)
+      warned_no_headings = false
+      pages = 0
+      settled = false
+      MAX_TOC_PASSES.times do
+        pages, headings = pass.call(size_gutter ? gutter : -1.0, desired_toc)
+        rebuilt = toc ? toc_html(headings, toc_depth, toc_title, pageless) : nil
+        if toc && rebuilt.nil? && !warned_no_headings
+          warn_missing_toc(headings, toc_depth)
+          warned_no_headings = true
+        end
+        needed_gutter = size_gutter ? kdp_gutter_mm(pages) : gutter
+        if needed_gutter == gutter && rebuilt == desired_toc
+          settled = true
+        else
+          gutter = needed_gutter
+          desired_toc = rebuilt
+        end
+      end
+      if toc && !settled && desired_toc
+        STDERR.puts "markpdf: warning: TOC page numbers did not settle after #{MAX_TOC_PASSES} passes; they may be off"
+      end
+      pages
+    end
+
     # Render markdown source to a PDF file in one shot: a convenience
     # that builds a throwaway Renderer. See Pdf::Renderer for the
     # reusable, library-friendly form. header/footer templates support
@@ -278,33 +332,31 @@ module Markd
     # code_theme picks the syntax-highlighting theme explicitly.
     # pageless produces a single page as tall as the document (good
     # for on-screen viewing, wrong for printing); headers and footers
-    # are ignored in that mode.
+    # are ignored in that mode. toc prepends a two-pass table of
+    # contents listing headings down to toc_depth, each entry linking
+    # to its section; see settled_pages for how the numbers settle.
     def self.render(source : String, output_path : String, options : Markd::Options = Markd::Options.new,
                     page_size : String = "a4", margin_mm : Float64 = 20.0, base_dir : String = ".",
                     header : String = "", footer : String = "", code_theme : String? = nil,
                     theme : String? = nil, html_input : Bool = false, style : String? = nil,
                     pageless : Bool = false, hyphenate : Bool = false, language : String = "en",
-                    css : String? = nil, margins : String? = nil, kdp : Bool = false) : Int32
+                    css : String? = nil, margins : String? = nil, kdp : Bool = false,
+                    mirror_headers : Bool = false, toc : Bool = false, toc_depth : Int32 = 1,
+                    toc_title : String = "Contents") : Int32
       if kdp && (margins.nil? || Pdf.parse_margins(margins).gutter < 0)
-        # KDP mode with no explicit gutter: size the gutter from the page
-        # count (Amazon's table). Page count depends on the margins, so
-        # iterate render -> gutter until it stabilizes (coarse brackets
-        # converge in one or two steps).
-        base = margins || margin_mm.to_s
-        parsed = parse_margins(base)
-        gutter = KDP_GUTTER_TABLE.first[2]
-        pages = 0
-        4.times do
-          guttered = margins_with_gutter(parsed, gutter)
+        # KDP mode with no explicit gutter: size the gutter from the
+        # page count (Amazon's table). Page count depends on the
+        # margins and — with a TOC — on the TOC block itself, so the
+        # settle loop re-renders until both stop moving.
+        parsed = parse_margins(margins || margin_mm.to_s)
+        pages = settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: true) do |gutter, desired_toc|
           renderer = Renderer.new(options: options, style: style || "default", theme: theme,
-            code_theme: code_theme, page_size: page_size, margins: guttered, kdp: true,
-            base_dir: base_dir, header: header, footer: footer, html_input: html_input,
-            pageless: pageless, hyphenate: hyphenate, language: language)
+            code_theme: code_theme, page_size: page_size, margins: margins_with_gutter(parsed, gutter),
+            kdp: true, mirror_headers: mirror_headers, base_dir: base_dir, header: header,
+            footer: footer, html_input: html_input, pageless: pageless, hyphenate: hyphenate,
+            language: language)
           renderer.add_css(css) if css
-          pages = renderer.render(source, output_path)
-          needed = kdp_gutter_mm(pages)
-          break if needed == gutter
-          gutter = needed
+          renderer.render_with_headings(source, output_path, desired_toc)
         end
         range_warning = kdp_range_warning(pages)
         STDERR.puts "markpdf: warning: #{range_warning}" if range_warning
@@ -315,10 +367,16 @@ module Markd
 
       renderer = Renderer.new(options: options, style: style || "default", theme: theme,
         code_theme: code_theme, page_size: page_size, margin_mm: margin_mm, margins: margins,
-        kdp: kdp, base_dir: base_dir, header: header, footer: footer, html_input: html_input,
-        pageless: pageless, hyphenate: hyphenate, language: language)
+        kdp: kdp, mirror_headers: mirror_headers, base_dir: base_dir, header: header, footer: footer,
+        html_input: html_input, pageless: pageless, hyphenate: hyphenate, language: language)
       renderer.add_css(css) if css
-      renderer.render(source, output_path)
+      if toc
+        settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: false) do |_, desired_toc|
+          renderer.render_with_headings(source, output_path, desired_toc)
+        end
+      else
+        renderer.render(source, output_path)
+      end
     end
 
     # Render markdown to PDF bytes in memory: a convenience that builds
@@ -329,13 +387,24 @@ module Markd
                               header : String = "", footer : String = "", code_theme : String? = nil,
                               theme : String? = nil, style : String? = nil, html_input : Bool = false,
                               pageless : Bool = false, hyphenate : Bool = false, language : String = "en",
-                              css : String? = nil, margins : String? = nil, kdp : Bool = false) : Bytes
+                              css : String? = nil, margins : String? = nil, kdp : Bool = false,
+                              mirror_headers : Bool = false, toc : Bool = false, toc_depth : Int32 = 1,
+                              toc_title : String = "Contents") : Bytes
       renderer = Renderer.new(options: options, style: style || "default", theme: theme, code_theme: code_theme,
-        page_size: page_size, margin_mm: margin_mm, margins: margins, kdp: kdp, base_dir: base_dir,
-        header: header, footer: footer, html_input: html_input, pageless: pageless,
-        hyphenate: hyphenate, language: language)
+        page_size: page_size, margin_mm: margin_mm, margins: margins, kdp: kdp,
+        mirror_headers: mirror_headers, base_dir: base_dir, header: header, footer: footer,
+        html_input: html_input, pageless: pageless, hyphenate: hyphenate, language: language)
       renderer.add_css(css) if css
-      renderer.render_to_memory(source)
+      return renderer.render_to_memory(source) unless toc
+      # The settle loop only reports pages and headings, so the closure
+      # keeps the last render's bytes aside for the final return.
+      final_bytes = Bytes.new(0)
+      settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: false) do |_, desired_toc|
+        bytes, pages, headings = renderer.render_to_memory_with_headings(source, desired_toc)
+        final_bytes = bytes
+        {pages, headings}
+      end
+      final_bytes
     end
 
     # Internal: called by Pdf::Renderer. Soft hyphens go in last: they
@@ -363,6 +432,84 @@ module Markd
           %(<li class="task-list-item"><span class="task-box">☑</span>))
         .gsub(%r{<li><input disabled="" type="checkbox">},
           %(<li class="task-list-item"><span class="task-box">☐</span>))
+    end
+
+    # One collected heading, as the shim's heading map reports it:
+    # index counts headings with visible text in document order (the
+    # same numbering as the #mtoc-N anchor ids rewrite_heading_anchors
+    # injects), level is 1-6, page is the 1-based page the heading
+    # lands on (0 when it fell on no page window), title is the
+    # whitespace-collapsed heading text.
+    record HeadingEntry, index : Int32, level : Int32, page : Int32, title : String
+
+    # Parse the shim's heading map ("index\tlevel\tpage\ttitle" per
+    # line) into HeadingEntry records. Soft hyphens are stripped: they
+    # only make sense in the flowed body text, not in TOC entry titles.
+    def self.parse_heading_map(map : String) : Array(HeadingEntry)
+      headings = [] of HeadingEntry
+      map.each_line do |line|
+        fields = line.split('\t', 4)
+        next unless fields.size == 4
+        headings << HeadingEntry.new(fields[0].to_i, fields[1].to_i, fields[2].to_i,
+          fields[3].gsub('\u{00AD}', ""))
+      end
+      headings
+    end
+
+    # Number every heading with visible text: an empty <a id="mtoc-N">
+    # anchor goes in as the heading's first child, N counting headings
+    # in document order. The shim numbers its heading map the same way
+    # (visible text, document order), so TOC entries built from the map
+    # link to the right heading. The empty anchor contributes no text,
+    # so heading titles and the PDF outline stay unchanged.
+    def self.rewrite_heading_anchors(html : String) : String
+      anchor_index = 0
+      html.gsub(%r{<h([1-6])([^>]*)>(.*?)</h\1>}m) do |match|
+        if $3.gsub(/<[^>]*>/, "").strip.empty?
+          match
+        else
+          anchor_index += 1
+          "<h#{$1}#{$2}><a id=\"mtoc-#{anchor_index}\"></a>#{$3}</h#{$1}>"
+        end
+      end
+    end
+
+    # Place the TOC ahead of the content: markdown bodies are fragments
+    # and just get it prepended, complete HTML documents get it inside
+    # the <body> element so doctype and head stay intact. The forced
+    # break to the body rides an empty div, not the nav: the shim's
+    # page-break properties inherit down the tree, and a break on the
+    # nav would give every TOC entry its own page.
+    def self.inject_toc(html : String, toc : String) : String
+      toc = toc + "<div style=\"page-break-after: always\"></div>"
+      if html.matches?(/<body[^>]*>/)
+        html.sub(/<body[^>]*>/) { |body_tag| "#{body_tag}\n#{toc}" }
+      else
+        "#{toc}\n#{html}"
+      end
+    end
+
+    # The TOC block injected ahead of the body: a title div —
+    # deliberately not an <h1>, or it would self-list in the heading
+    # map, trigger the kdp recto rule and land in the bookmarks — and
+    # one linked entry per heading at or above the depth filter.
+    # Entries whose heading fell on no page (page 0) are dropped, and
+    # pageless documents have no page numbers to show. Nil when no
+    # heading survives the filters: the caller renders without a TOC.
+    def self.toc_html(headings : Array(HeadingEntry), depth : Int32, title : String, pageless : Bool) : String?
+      entries = headings.reject { |heading| heading.level > depth || heading.page == 0 }
+      return if entries.empty?
+      lines = entries.map do |heading|
+        page = pageless ? "" : %(<span class="toc-page">#{heading.page}</span>)
+        %(<div class="toc-entry toc-level-#{heading.level}"><a href="#mtoc-#{heading.index}">) +
+          %(<span class="toc-text">#{HTML.escape(heading.title)}</span>#{page}</a></div>)
+      end
+      <<-HTML
+        <nav class="toc">
+        <div class="toc-title">#{HTML.escape(title)}</div>
+        #{lines.join("\n")}
+        </nav>
+        HTML
     end
 
     # Internal: called by Pdf::Renderer. Rewrite <img> sources the shim

--- a/src/pdf_renderer.cr
+++ b/src/pdf_renderer.cr
@@ -48,23 +48,41 @@ module Markd
       # Render markdown — or a complete HTML document — to output_path.
       # Returns the page count; raises Markd::Pdf::Error on failure.
       def render(source : String, output_path : String) : Int32
+        render_with_headings(source, output_path)[0]
+      end
+
+      # Render with an optional TOC block, as Pdf.toc_html builds it:
+      # the block is injected ahead of the body and every heading gets
+      # a #mtoc-N anchor the entries can link to. Returns the page
+      # count and the heading map the layout produced (index, level,
+      # 1-based page, title per heading) — the raw material the
+      # two-pass TOC in Markd::Pdf.settled_pages rebuilds the block
+      # from. Raises Markd::Pdf::Error on failure.
+      def render_with_headings(source : String, output_path : String,
+                               toc_html : String? = nil) : {Int32, Array(HeadingEntry)}
         temp_dir = File.join(Dir.tempdir, "markpdf-imgs-#{Process.pid}-#{Time.utc.to_unix_ms}")
         Dir.mkdir(temp_dir, 0o700)
         converted = [] of String
         begin
-          geometry = prepare(source, temp_dir, converted)
+          geometry = prepare(source, temp_dir, converted, toc_html)
           errbuf = Bytes.new(512)
+          heading_data = Pointer(LibC::Char).null
+          heading_len = LibC::SizeT.new(0)
           pages = Litepdf.render(geometry[:html], nil, geometry[:width_mm].to_f32,
             geometry[:height_mm].to_f32, geometry[:margin_top].to_f32,
             geometry[:margin_right].to_f32, geometry[:margin_bottom].to_f32,
             geometry[:margin_left].to_f32, geometry[:margin_gutter].to_f32, output_path,
             @base_dir, @header, @footer, geometry[:background], errbuf, errbuf.size,
-            @pageless ? 1 : 0, @kdp ? 1 : 0, @mirror_headers ? 1 : 0)
+            @pageless ? 1 : 0, @kdp ? 1 : 0, @mirror_headers ? 1 : 0,
+            pointerof(heading_data), pointerof(heading_len))
           if pages < 0
             message = String.new(errbuf).strip
             raise Error.new(message.empty? ? "PDF rendering failed" : message)
           end
-          pages
+          headings = heading_data.null? ? [] of HeadingEntry : Pdf.parse_heading_map(
+            String.new(Slice.new(heading_data, heading_len.to_i)))
+          Litepdf.free_buffer(heading_data) unless heading_data.null?
+          {pages, headings}
         ensure
           converted.each { |path| File.delete?(path) }
           begin
@@ -79,13 +97,22 @@ module Markd
       # converting pass through a private temp directory, deleted right
       # after the render. Raises Markd::Pdf::Error on failure.
       def render_to_memory(source : String) : Bytes
+        render_to_memory_with_headings(source)[0]
+      end
+
+      # The in-memory twin of render_with_headings: same TOC block and
+      # heading map, but the PDF comes back as bytes instead of a file.
+      def render_to_memory_with_headings(source : String,
+                                         toc_html : String? = nil) : {Bytes, Int32, Array(HeadingEntry)}
         temp_dir = File.join(Dir.tempdir, "markpdf-imgs-#{Process.pid}-#{Time.utc.to_unix_ms}")
         Dir.mkdir(temp_dir, 0o700)
         converted = [] of String
         begin
           out_data = Pointer(LibC::Char).null
           out_len = LibC::SizeT.new(0)
-          geometry = prepare(source, temp_dir, converted)
+          heading_data = Pointer(LibC::Char).null
+          heading_len = LibC::SizeT.new(0)
+          geometry = prepare(source, temp_dir, converted, toc_html)
           errbuf = Bytes.new(512)
           pages = Litepdf.render_to_memory(geometry[:html], nil, geometry[:width_mm].to_f32,
             geometry[:height_mm].to_f32, geometry[:margin_top].to_f32,
@@ -93,14 +120,18 @@ module Markd
             geometry[:margin_left].to_f32, geometry[:margin_gutter].to_f32, @base_dir,
             @header, @footer, geometry[:background], errbuf, errbuf.size,
             @pageless ? 1 : 0, @kdp ? 1 : 0, @mirror_headers ? 1 : 0,
-            pointerof(out_data), pointerof(out_len))
+            pointerof(out_data), pointerof(out_len),
+            pointerof(heading_data), pointerof(heading_len))
           if pages < 0
             message = String.new(errbuf).strip
             raise Error.new(message.empty? ? "PDF rendering failed" : message)
           end
           bytes = Slice.new(out_data, out_len.to_i).dup
+          headings = heading_data.null? ? [] of HeadingEntry : Pdf.parse_heading_map(
+            String.new(Slice.new(heading_data, heading_len.to_i)))
           Litepdf.free_buffer(out_data)
-          bytes
+          Litepdf.free_buffer(heading_data) unless heading_data.null?
+          {bytes, pages, headings}
         ensure
           converted.each { |path| File.delete?(path) }
           begin
@@ -110,11 +141,12 @@ module Markd
         end
       end
 
-      # Everything both render methods share: markdown or HTML in, final
-      # document HTML out, with images materialized into temp_dir and the
-      # page geometry resolved.
+      # Everything the render methods share: markdown or HTML in, final
+      # document HTML out, with images materialized into temp_dir and
+      # the page geometry resolved. toc_html, when given, goes ahead of
+      # the body; every heading gets the anchor its entries link to.
       private def prepare(source : String, temp_dir : String,
-                          converted : Array(String)) : NamedTuple(
+                          converted : Array(String), toc_html : String? = nil) : NamedTuple(
         html: String, width_mm: Float64, height_mm: Float64,
         margin_top: Float64, margin_right: Float64, margin_bottom: Float64,
         margin_left: Float64, margin_gutter: Float64, background: String)
@@ -133,9 +165,13 @@ module Markd
           # No markdown processing, no skeleton: the document keeps
           # its own styles and title.
           html = Pdf.process_images(source, @base_dir, temp_dir, converted)
+          html = Pdf.inject_toc(Pdf.rewrite_heading_anchors(html), toc_html) if toc_html
         else
           body_html = Pdf.process_images(MathRender.rewrite_html(Pdf.rewrite_task_lists(Markd.to_html(source, @options, formatter: formatter))), @base_dir, temp_dir, converted)
           body_html = Pdf.hyphenate_body(body_html, @hyphenate, @language)
+          if toc_html
+            body_html = Pdf.inject_toc(Pdf.rewrite_heading_anchors(body_html), toc_html)
+          end
           html = Pdf.document_html(body_html, css, extra_css: formatter.style_defs)
         end
         page_width_mm, page_height_mm = Pdf.parse_page_size(@page_size)

--- a/src/pdf_styles.cr
+++ b/src/pdf_styles.cr
@@ -34,6 +34,26 @@ module Markd
       "sepia"   => "warm paper tones, serif — e-reader default look",
     }
 
+    # Table of contents layout, interpolated into every style so they
+    # keep covering the same property set: entries are blocks with a
+    # right-floating page number (litehtml has no ::after or leader(),
+    # so no dot leaders), and colors inherit so one block fits all
+    # four looks. No page-break rule here on purpose: the shim's
+    # page-break properties inherit down the tree, and a break on the
+    # nav would give every entry its own page — the break to the body
+    # rides an empty div inject_toc adds instead.
+    TOC_CSS = <<-CSS
+      .toc-title { font-size: 1.7em; font-weight: bold; margin: 0 0 1em 0; }
+      .toc-entry { margin: 0 0 2px 0; }
+      .toc-entry a { color: inherit; text-decoration: none; }
+      .toc-page { float: right; }
+      .toc-level-2 { margin-left: 1.5em; }
+      .toc-level-3 { margin-left: 3em; }
+      .toc-level-4 { margin-left: 4.5em; }
+      .toc-level-5 { margin-left: 6em; }
+      .toc-level-6 { margin-left: 7.5em; }
+      CSS
+
     STYLES = {
       "default" => <<-CSS,
         body { font-family: "DejaVu Sans", Helvetica, Arial, sans-serif; font-size: 11px; line-height: 1.5; color: #1a1a1a; margin: 0; padding: 0; }
@@ -82,6 +102,7 @@ module Markd
         .math { font-family: "DejaVu Serif", Georgia, serif; font-style: italic; }
         .math.block { display: block; text-align: center; margin: 6px 0 6px 0; }
         pre.math { text-align: left; background-color: transparent; border: none; line-height: 1.1; margin: 6px auto 6px auto; }
+        #{TOC_CSS}
         CSS
       "book" => <<-CSS,
         body { font-family: "DejaVu Serif", Georgia, serif; font-size: 12px; line-height: 1.6; color: #1a1a1a; margin: 0; padding: 0; }
@@ -132,6 +153,7 @@ module Markd
         .math { font-family: "DejaVu Serif", Georgia, serif; font-style: italic; }
         .math.block { display: block; text-align: center; margin: 6px 0 6px 0; }
         pre.math { text-align: left; background-color: transparent; border: none; line-height: 1.1; margin: 6px auto 6px auto; }
+        #{TOC_CSS}
         CSS
       "dark" => <<-CSS,
         body { font-family: "DejaVu Sans", Helvetica, Arial, sans-serif; font-size: 11px; line-height: 1.5; color: #e8e8e8; background-color: #121212; margin: 0; padding: 0; }
@@ -180,6 +202,7 @@ module Markd
         .math { font-family: "DejaVu Serif", Georgia, serif; font-style: italic; }
         .math.block { display: block; text-align: center; margin: 6px 0 6px 0; }
         pre.math { text-align: left; background-color: transparent; border: none; line-height: 1.1; margin: 6px auto 6px auto; }
+        #{TOC_CSS}
         CSS
       "sepia" => <<-CSS
         body { font-family: "DejaVu Serif", Georgia, serif; font-size: 12px; line-height: 1.6; color: #5b4636; background-color: #f4ecd8; margin: 0; padding: 0; }
@@ -228,6 +251,7 @@ module Markd
         .math { font-family: "DejaVu Serif", Georgia, serif; font-style: italic; }
         .math.block { display: block; text-align: center; margin: 6px 0 6px 0; }
         pre.math { text-align: left; background-color: transparent; border: none; line-height: 1.1; margin: 6px auto 6px auto; }
+        #{TOC_CSS}
         CSS
     }
 


### PR DESCRIPTION
## What

`markpdf --toc` prepends a table of contents with real page numbers, where every entry links to its section. This closes the gap KDP.md documented — "The tool has no two-pass TOC; write it by hand after the layout settles."

- `--toc` — prepend the TOC
- `--toc-depth N` — deepest heading level listed, 1 (chapters only) to 6 (default 1)
- `--toc-title T` — heading above the list (default "Contents")
- `--pageless` + `--toc` — entries without page numbers (there are no pages)
- library: `toc:`, `toc_depth:`, `toc_title:` kwargs on `Markd::Pdf.render` / `render_to_memory`

## How

The C++ shim already computed each heading's page for the PDF outline and threw the mapping away. It now also returns a heading map (`index\tlevel\tpage\ttitle` per heading) to Crystal.

On top of that, `Markd::Pdf.settled_pages` runs the numbers to a fixed point: render → read where the headings actually landed → rebuild the TOC block → re-render, until what the TOC says matches where things are. The TOC's own length shifts every page after it, so one pass can never know its numbers. Two or three passes converge; the cap is 6 with a stderr warning if a pathological document never settles.

Entries are clickable: `rewrite_heading_anchors` injects a unique `#mtoc-N` anchor into every heading with visible text (same numbering the shim's map uses), and each entry links to it via the shim's existing internal-link machinery. The vendored markd's `toc?` anchors are deliberately not used (lib/ is off-limits and not duplicate-safe).

## Notable findings along the way

- **litehtml page-break properties inherit down the tree** (`html_tag.cpp:347` resolves custom properties through ancestors). A `page-break-after: always` on the nav gave every TOC entry its own page (1-page doc → 8 pages). The forced break to the body now rides an empty div after the nav.
- The kdp gutter iteration folded into the same settle loop (page count depends on margins *and* the TOC block), and the CLI's kdp path now routes through the library instead of duplicating it — which also fixes `--mirror-headers` being dropped in kdp mode.
- The TOC title is a styled `<div>`, not an `<h1>`, so it never self-lists, triggers the kdp recto rule, or lands in the bookmarks.

## Verification

- 17 new specs in `spec/pdf_toc_spec.cr`: map parsing, anchor numbering alignment, block building/filters, heading-map layout, the real two-pass test (40 chapters: every TOC number equals the page where that chapter actually renders), kdp recto+filler numbering, pageless, CLI flag handling
- Full suite: 252 examples, 0 failures, 1 pre-existing pending
- `ameba` clean; all four binaries build (`shards build`); shim builds (`make -C ext`)
- Manual smoke: multi-page TOC convergence, kdp fillers counted in numbers, clickable /Link annotations present, HTML input, pageless, no-headings warning, invalid `--toc-depth` aborts

Docs: README (flag reference + a TOC section) and KDP.md (gap paragraph replaced with how the TOC plays with recto fillers and the even-page pad).