### PR TITLE
fix: keep page cuts from slicing line descenders onto the next page

### DIFF
--- a/ext/litepdf.cpp
+++ b/ext/litepdf.cpp
@@ -2322,12 +2322,11 @@ class PdfContainer : public litehtml::document_container
     // snaps those onto page window edges (see draw_borders).
     std::multiset<int> cell_edges;
 
-    // Glyph box (top, bottom) of every text run, in document
-    // coordinates. litehtml hangs runs below their line box (the
-    // baseline lands on the line-box bottom), so a page cut that
-    // coincides with a line top slices the previous line's descent
-    // zone; render_pdf maps these into flow space and hands them to
-    // snap_cut_above_runs.
+    // Glyph box (top, bottom) of every ink-bearing text run, in
+    // document coordinates. Pagination cuts are floored integers while
+    // layout positions are fractional, so a cut can still land a
+    // fraction inside a run box; render_pdf maps these into flow space
+    // and hands them to snap_cut_above_runs.
     std::vector<std::pair<float, float>> run_extents;
 
     // Lift a page cut above every text run box it would slice deeply:
@@ -2618,12 +2617,24 @@ class PdfContainer : public litehtml::document_container
         float abs_x = offset_x + px(pos.x);
         float abs_y = offset_y + px(pos.y);
         std::string tag = item->src_el() ? item->src_el()->get_tagName() : "";
-        if (getenv("LITEPDF_WALK")) std::fprintf(stderr, "walk tag=%s y=%.1f h=%.1f atomic=%d\n",
-            item->src_el() ? item->src_el()->get_tagName() : "?", abs_y, px(pos.height), (int)inside_atomic);
-        // Text runs feed the cut-snapping in render_pdf (see
+        std::string text;
+        bool whitespace_only = false;
+        if (item->src_el() && item->src_el()->is_text())
+        {
+            item->src_el()->get_text(text);
+            whitespace_only = text.find_first_not_of(" \t\n\r\f\v") == std::string::npos;
+        }
+        if (getenv("LITEPDF_WALK"))
+        {
+            std::fprintf(stderr, "walk tag=%s y=%.1f x=%.1f w=%.1f h=%.1f atomic=%d text='%s'\n",
+                item->src_el() ? item->src_el()->get_tagName() : "?", abs_y, abs_x, px(pos.width),
+                px(pos.height), (int)inside_atomic, text.c_str());
+        }
+        // Text runs feed the cut-snapping safety net (see
         // snap_cut_above_runs): the drawn box is what position::round
         // makes of the layout box, so record the same rounding here.
-        if (item->src_el() && item->src_el()->is_text() && px(pos.height) > 0)
+        // Whitespace-only elements carry no ink and are skipped.
+        if (item->src_el() && item->src_el()->is_text() && !whitespace_only && px(pos.height) > 0)
         {
             float run_top = std::round(offset_y + px(pos.y));
             run_extents.push_back({run_top, run_top + std::round(px(pos.height))});
@@ -2632,8 +2643,20 @@ class PdfContainer : public litehtml::document_container
         // backgrounds and borders of the element together with its text.
         // A heading's own bottom edge is never a cut point: breaking
         // there strands the heading at the bottom of a page.
+        //
+        // Text parts and inline boxes never seed candidates: their
+        // boxes sit inside line boxes, offset by the half-leading, so a
+        // cut on one of them lands mid-line-box — either shearing the
+        // previous line's descenders onto the next page or pulling the
+        // first line's leading into the margin. Every real text
+        // boundary is already covered by the line box tops collected
+        // further down.
+        litehtml::style_display display =
+            item->src_el() ? item->src_el()->css().get_display() : litehtml::display_block;
+        bool is_inline_box =
+            display == litehtml::display_inline_text || display == litehtml::display_inline;
         bool is_heading = tag.size() == 3 && tag[0] == 'h' && tag[1] >= '1' && tag[1] <= '6';
-        if (px(pos.width) > 0 || px(pos.height) > 0)
+        if ((px(pos.width) > 0 || px(pos.height) > 0) && !is_inline_box)
         {
             candidates.insert((int)std::floor(offset_y + px(item->top())));
             // A block's bottom edge is a cut point too: breaking exactly
@@ -3135,9 +3158,9 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
             if (next_forced < forced.size() && forced[next_forced].y <= start + content_height)
             {
                 ForcedCut cut = forced[next_forced];
-                // Even a user-requested break must not slice a line
-                // box: litehtml hangs runs below it, so the cut lands
-                // in the previous line's descent zone.
+                // A forced cut must not slice a line either: flooring
+                // the element boundary can leave the cut a fraction
+                // inside the previous line's descent zone.
                 float cut_y = PdfContainer::snap_cut_above_runs(run_boxes, start, cut.y);
                 windows.push_back({start, cut_y, false});
                 start = cut_y;

--- a/ext/litepdf.cpp
+++ b/ext/litepdf.cpp
@@ -1633,9 +1633,16 @@ class PdfContainer : public litehtml::document_container
         // flow space: wide tables draw with doc-space positions).
         if (context->paginated)
         {
-            float text_top = context->flow_y(px(pos.y));
+            float text_top    = context->flow_y(px(pos.y));
             float text_bottom = context->flow_y(px(pos.y + pos.height));
             if (text_top >= context->window_second || text_bottom <= context->window_first)
+            {
+                return;
+            }
+            // A run starting above this window belongs to the previous
+            // page: its below-cut part would otherwise render here,
+            // over the next page's top edge (ghost descender tails).
+            if (text_top < context->window_first)
             {
                 return;
             }
@@ -2315,6 +2322,51 @@ class PdfContainer : public litehtml::document_container
     // snaps those onto page window edges (see draw_borders).
     std::multiset<int> cell_edges;
 
+    // Glyph box (top, bottom) of every text run, in document
+    // coordinates. litehtml hangs runs below their line box (the
+    // baseline lands on the line-box bottom), so a page cut that
+    // coincides with a line top slices the previous line's descent
+    // zone; render_pdf maps these into flow space and hands them to
+    // snap_cut_above_runs.
+    std::vector<std::pair<float, float>> run_extents;
+
+    // Lift a page cut above every text run box it would slice deeply:
+    // a run with top in (start, cut) whose bottom reaches past the cut
+    // straddles the page boundary, and its below-cut part (descenders)
+    // would render at the top of the next page. Moving the cut to the
+    // straddling run's top pushes the whole line to the next page.
+    // Shallow slices (a point or two of descender tip, from flooring
+    // drift at block boundaries) are not worth moving a line for and
+    // are left to the draw-time ownership skip in draw_text; a slice
+    // past the descent zone's midpoint means the baseline itself sits
+    // at the cut — the whole descent renders on the next page — so the
+    // line moves. The extents must be sorted by top so each pass can
+    // stop at the cut; runs can overlap (fallback fonts, vertical
+    // shifts), so repeat until nothing straddles deeply.
+    static float snap_cut_above_runs(const std::vector<std::pair<float, float>>& extents,
+                                     float start, float cut)
+    {
+        const float deep_slice = 2.0f;
+        bool moved = true;
+        while (moved)
+        {
+            moved = false;
+            for (const auto& extent : extents)
+            {
+                if (extent.first >= cut)
+                {
+                    break;
+                }
+                if (extent.first > start && extent.second > cut + deep_slice)
+                {
+                    cut   = extent.first;
+                    moved = true;
+                }
+            }
+        }
+        return cut;
+    }
+
     void finalize_wide_tables()
     {
         std::sort(wide_tables.begin(), wide_tables.end(),
@@ -2568,6 +2620,14 @@ class PdfContainer : public litehtml::document_container
         std::string tag = item->src_el() ? item->src_el()->get_tagName() : "";
         if (getenv("LITEPDF_WALK")) std::fprintf(stderr, "walk tag=%s y=%.1f h=%.1f atomic=%d\n",
             item->src_el() ? item->src_el()->get_tagName() : "?", abs_y, px(pos.height), (int)inside_atomic);
+        // Text runs feed the cut-snapping in render_pdf (see
+        // snap_cut_above_runs): the drawn box is what position::round
+        // makes of the layout box, so record the same rounding here.
+        if (item->src_el() && item->src_el()->is_text() && px(pos.height) > 0)
+        {
+            float run_top = std::round(offset_y + px(pos.y));
+            run_extents.push_back({run_top, run_top + std::round(px(pos.height))});
+        }
         // Candidates use the margin/border-box top: breaking there keeps
         // backgrounds and borders of the element together with its text.
         // A heading's own bottom edge is never a cut point: breaking
@@ -2965,6 +3025,15 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
     {
         candidates.insert(candidates.begin(), 0);
     }
+    // Text run boxes in flow space, sorted by top: the cut snapper
+    // (snap_cut_above_runs) scans them at every page boundary.
+    std::vector<std::pair<float, float>> run_boxes;
+    run_boxes.reserve(container.run_extents.size());
+    for (const auto& extent : container.run_extents)
+    {
+        run_boxes.push_back({container.flow_y(extent.first), container.flow_y(extent.second)});
+    }
+    std::sort(run_boxes.begin(), run_boxes.end());
     // Keep-with-next: breaking at the element right after a heading
     // strands the heading at the bottom of a page (a widow title), so
     // such candidates are avoided unless nothing better fits. The flag
@@ -3066,8 +3135,12 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
             if (next_forced < forced.size() && forced[next_forced].y <= start + content_height)
             {
                 ForcedCut cut = forced[next_forced];
-                windows.push_back({start, cut.y, false});
-                start = cut.y;
+                // Even a user-requested break must not slice a line
+                // box: litehtml hangs runs below it, so the cut lands
+                // in the previous line's descent zone.
+                float cut_y = PdfContainer::snap_cut_above_runs(run_boxes, start, cut.y);
+                windows.push_back({start, cut_y, false});
+                start = cut_y;
                 next_forced++;
                 // A chapter opening on a named page gets a blank filler
                 // when the cut would land on the wrong parity: right
@@ -3129,6 +3202,16 @@ static int render_pdf(const char* html, const char* css, float page_width_mm, fl
                     }
                 }
             }
+            // A cut landing inside a text run slices its descenders
+            // off at the page edge and re-renders them on the next
+            // page: lift the cut above the run, pushing the whole
+            // line over (see snap_cut_above_runs).
+            float snapped = PdfContainer::snap_cut_above_runs(run_boxes, start, next);
+            if (getenv("LITEPDF_DEBUG") && snapped != next)
+            {
+                std::fprintf(stderr, "page cut snapped %.1f -> %.1f\n", next, snapped);
+            }
+            next = snapped;
             windows.push_back({start, next, false});
             start = next;
         }

--- a/spec/pdf_pagination_spec.cr
+++ b/spec/pdf_pagination_spec.cr
@@ -93,6 +93,31 @@ private def pages_containing(page_texts : Array(String), token : String) : Array
   pages
 end
 
+# Boundaries where a word gram of the earlier page's trailing line
+# reappears as a run on the next page: the signature of a line box
+# straddling a page cut, drawn on both sides of it — glyph bodies on
+# the earlier page, its below-cut sliver (descender tails) above the
+# next page's first line.
+private def ghost_boundaries(page_texts : Array(String), gram_size : Int32 = 4) : Array(Int32)
+  boundaries = Array(Int32).new
+  page_texts.each_with_index do |text, page_index|
+    next_page = page_texts[page_index + 1]?
+    break if next_page.nil?
+    tail_words = text.split.last(6)
+    next if tail_words.size < gram_size
+    next_words = next_page.split
+    next if next_words.size < gram_size
+    ghosted = (0..tail_words.size - gram_size).any? do |offset|
+      gram = tail_words[offset, gram_size]
+      (0..next_words.size - gram_size).any? do |start|
+        next_words[start, gram_size] == gram
+      end
+    end
+    boundaries << page_index + 1 if ghosted
+  end
+  boundaries
+end
+
 # Extract the per-page sequences of "item N" numbers and check the
 # integrity contract described above.
 private def should_draw_items_in_order(page_texts : Array(String), count : Int32, label : String)
@@ -298,6 +323,51 @@ it "never strands a section heading at the bottom of a page" do
       page_texts[heading_pages.first - 1].should contain("opens with its first line"),
         "section #{section}: heading stranded at the bottom of page #{heading_pages.first} without its body"
     end
+  ensure
+    File.delete?(path)
+  end
+end
+
+# litehtml hangs text runs a few points below their line box (the
+# baseline lands on the line-box bottom), so a page cut coinciding
+# with a line top used to slice the page-bottom line's descent zone:
+# the straddling run was drawn on both pages, glyph bodies clipped at
+# the earlier page's bottom edge and the descender tails rendered
+# above the next page's first line. Pagination now snaps such cuts
+# above the straddling run, and draw_text skips runs starting above
+# the window — either way the boundary line's words must show up on
+# exactly one page.
+it "never bleeds a page-bottom line's descenders onto the next page" do
+  pdftotext = pdftotext_path
+  pending!("pdftotext not available") unless pdftotext
+
+  # Descender-heavy word salad, seeded per paragraph: page breaks
+  # landing inside a paragraph put a descender-laden line at the page
+  # bottom, the geometry where cuts coincide with line tops.
+  words = %w[
+    gypy gyppy quipping pygmy jaunty jauntily yapping djinny hypnotizing
+    puzzled gripping jockey quickening hiking jumping paddling querying
+    yoyoing squeeging japing quaking hopscotch typing paddocks quibbling
+    eyepopping hijacking jogging keypunching quagmire mythology geography
+    psychology typography epidemiology cryptography
+  ]
+  source = String.build do |io|
+    io << "# descendersentinel\n\n"
+    1.upto(120) do |paragraph_number|
+      random = Random.new(paragraph_number * 1000)
+      io << words.sample(60, random).join(" ") << ".\n\n"
+    end
+  end
+
+  path = temp_pdf_path
+  begin
+    pages = Markd::Pdf.render(source, path, style: "book")
+    pages.should be >= 8
+
+    page_texts = (1..pages).map { |page| page_text(pdftotext, path, page) }
+    ghosted = ghost_boundaries(page_texts)
+    ghosted.should be_empty,
+      "page-bottom lines duplicated on the next page at boundaries: #{ghosted}"
   ensure
     File.delete?(path)
   end

--- a/spec/pdf_pagination_spec.cr
+++ b/spec/pdf_pagination_spec.cr
@@ -328,15 +328,15 @@ it "never strands a section heading at the bottom of a page" do
   end
 end
 
-# litehtml hangs text runs a few points below their line box (the
-# baseline lands on the line-box bottom), so a page cut coinciding
-# with a line top used to slice the page-bottom line's descent zone:
-# the straddling run was drawn on both pages, glyph bodies clipped at
-# the earlier page's bottom edge and the descender tails rendered
-# above the next page's first line. Pagination now snaps such cuts
-# above the straddling run, and draw_text skips runs starting above
-# the window — either way the boundary line's words must show up on
-# exactly one page.
+# Text runs and inline boxes sit inside line boxes, offset by the
+# half-leading, so a page cut landing on one of their boxes shears the
+# line at an arbitrary height: glyph bodies clipped at the earlier
+# page's bottom edge and the descender tails rendered above the next
+# page's first line. Inline boxes no longer seed break candidates
+# (line box tops and block edges do), cuts that still slice a run snap
+# above it, and draw_text skips runs starting above the window — any
+# way around, the boundary line's words must show up on exactly one
+# page.
 it "never bleeds a page-bottom line's descenders onto the next page" do
   pdftotext = pdftotext_path
   pending!("pdftotext not available") unless pdftotext


### PR DESCRIPTION
## Problem

In paginated PDF output, the descending strokes of a page's last line (g, y, p, q tails) could reappear as ghost slivers at the top of the next page.

## Root cause

Page-break candidates were seeded by **every** render item — including text runs and inline boxes. Those boxes sit *inside* their line box (offset by the half-leading; litehtml even leaves some whitespace-only elements flush at the line-box top), so a cut landing on one of them fell mid-line-box: the straddling run was drawn on **both** pages — glyph bodies clipped at the earlier page's bottom edge, and the below-cut part (the descender tails) rendered above the next page's first line. It also made first lines start at inconsistent distances below the top margin, depending on which box kind the cut landed on.

Reproduced with a descender-heavy prose document (`--style book`): a full row of floating descender tails at the top of a page, and 6 ghosted boundaries document-wide in the text layer.

## Fix

In `ext/litepdf.cpp`:

1. **Only block edges and line box tops seed break candidates.** Text parts and inline boxes are excluded — their boxes are never a meaningful place to break, and line box tops (from `for_inline_boxes`) plus block margins/borders already cover every real text boundary.
2. **Cut snapping safety net** (`snap_cut_above_runs`): any cut that would still slice a text run deeper than 2pt — flooring drift, forced breaks, exotic content — is lifted above the run, moving the whole line to the next page.
3. **Draw-time ownership**: `draw_text` skips runs starting above the page window, so a residual straddle can never paint on the next page and the PDF text layer stops carrying duplicated boundary lines.

Note litehtml's line layout itself was verified correct (runs centered in line boxes per CSS half-leading, confirmed by instrumenting the line-box math); the vendored copy is unchanged. `LITEPDF_WALK` debug output now includes x, width and element text, which is what exposed the stray-box geometry.

## Verification

- New regression spec: renders a multi-page descender-heavy document (book style) and asserts no boundary line's trailing words reappear on the next page. Fails on the old code, passes now.
- Text-layer ghost check across book/default/sepia/dark on a 20+ page document: 6–24 ghosted boundaries before → **0** after.
- First-line rhythm: the gap between the top margin and the first line's ink was 1.6–7.8pt (page-dependent) before; it is now **exactly 5.0pt on every page** (all 23 boundaries of the repro document), with zero ink ever drawn in the margin. Cut snapping no longer fires on ordinary prose (0 snaps).
- Full suite: 236 examples, 0 failures. Ameba: 0 issues. All four binaries build.

## Side effect to be aware of

Documents re-paginate slightly: cuts previously landed mid-line-box, stealing a few points of leading per page, so the repro document grew from 21 to 24 pages. The new counts are the typographically honest ones (whole lines, uniform margins), but real books — KDP submissions especially — should be re-checked for page count, parity padding, and running heads before printing.