### PR TITLE
docs: call the notes what they are — endnotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Done (markterm):
 * ✅ Maybe only support timg with options
 * ✅ Support being used in a pipeline
 * ✅ Task lists, GFM alerts, wrapped tables
-* ✅ Footnotes
+* ✅ Footnotes (rendered as endnotes: notes collect at the end of the
+  document)
 * ✅ Wrap styled table cells at word boundaries when tables are squeezed
 * ✅ Internal piping to $PAGER for tall documents (`--no-pager` opts out)
 * ✅ CLI switches for images and links (`--images`, `--no-images`,
@@ -348,8 +349,11 @@ HTML→PDF converter for the HTML subset litehtml supports.
 
 Links pointing at `http(s)://` or `mailto:` URIs become clickable PDF
 link annotations, and internal anchors (including footnote references
-and their back-links) jump to their targets. Fenced code blocks get
-tartrazine syntax highlighting (the `docopt` lexer included).
+and their back-links) jump to their targets. Note that the footnote
+syntax produces endnotes: definitions are collected in a section at
+the end of the document, not at the bottom of the referencing page.
+Fenced code blocks get tartrazine syntax highlighting (the `docopt`
+lexer included).
 
 Example with a dark base16 theme, page numbers and a header:
 

--- a/src/views/landing.ecr
+++ b/src/views/landing.ecr
@@ -98,7 +98,8 @@
         <article>
           <h3>GitHub Flavoured Markdown</h3>
           <p>Tables, task lists, GitHub-style alerts, strikethrough, math,
-          emoji, and real footnotes with backlinks — plus raw HTML when
+          emoji, and footnotes with backlinks — rendered as endnotes,
+          collected at the end of the document — plus raw HTML when
           markdown isn't enough.</p>
         </article>
         <article>

--- a/src/web.cr
+++ b/src/web.cr
@@ -324,7 +324,8 @@ module MarkpdfWeb
         **theme**, toggle **hyphenation**, set a **header** or **footer**,
         or check **pageless** for one long page.
 
-        [^1]: Yes, real footnotes with backlinks.
+        [^1]: Rendered as endnotes: the notes collect at the end of the
+        document, with backlinks.
         MD
     },
     {


### PR DESCRIPTION
## Summary

Docs and the website claimed support for "real footnotes", but what both `markterm` and `markpdf` actually implement are endnotes: footnote syntax (`[^1]`) collects definitions in a notes section at the **end of the document**, with backlinks — not at the bottom of the referencing page. This PR makes the docs say that.

- **README.md**: the markterm feature list now says footnotes are "rendered as endnotes: notes collect at the end of the document", and the markpdf links/anchors paragraph states plainly that the footnote syntax produces endnotes, not page-bottom footnotes.
- **Landing page** (`src/views/landing.ecr`): the GFM feature card drops the "real footnotes" claim and says "rendered as endnotes, collected at the end of the document".
- **Playground feature-tour sample** (`src/web.cr`): the table row still names the GFM syntax ("Footnotes"), but its footnote now reads "Rendered as endnotes: the notes collect at the end of the document, with backlinks."

Left alone on purpose: the CHANGELOG (history), `shard.yml` comments (upstream PR/branch names), the `.footnotes` CSS class (matches markd's HTML), and the rendered "Footnotes" section header itself — renaming that is a behavior/spec change, better decided separately.

## Verification

I rendered `Hello[^1] world...[^2]` through both binaries before touching anything: in terminal output and in extracted PDF text the notes appear after the body at the end, confirming the endnote behavior the new wording describes.

- `shards build`: all four binaries (`markterm`, `markmark`, `markpdf`, `markpdf-web`) compile
- `crystal spec`: 235 examples, 0 failures (1 pending, pre-existing)
- `ameba`: 33 inspected, 0 failures