### PR TITLE
feat: --toc-depth takes a level range like 2-6

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,10 @@ Options:
                              every entry links to its section. The layout
                              runs repeatedly until the numbers stop moving
                              (a TOC's own length shifts the pages it points to)
-  --toc-depth <depth>        Deepest heading level the TOC lists, from
-                             1 (chapters only) to 6 [default: 1]
+  --toc-depth <depth>        Deepest heading level the TOC lists, or a
+                             range N-M listing only levels N through M
+                             (2-6 skips a level-1 document title);
+                             levels run 1 to 6 [default: 1]
   --toc-title <title>        Title above the table of contents [default: Contents]
   --config <path>            Read options from this YAML file instead of
                              ~/.config/markpdf/config.yml
@@ -335,7 +337,11 @@ markpdf book.md --toc --toc-depth 2 --toc-title "Inhalt" --kdp -o book.pdf
 ```
 
 `--toc-depth` caps how deep the listing goes (1 = chapters only, up to
-6); `--toc-title` sets the heading above it. TOC pages are ordinary
+6), and also takes a range: `--toc-depth 2-6` lists everything *except*
+a level-1 document title — the usual shape of a markdown book whose H1
+is the title and whose H2s are the chapters (a narrower `N-M` lists
+only those levels, so `2-2` is chapter titles alone);
+`--toc-title` sets the heading above it. TOC pages are ordinary
 pages: they count toward the page count, the kdp recto rule and the
 even-page pad, and the TOC's numbers account for all of it. With
 `--pageless` the entries lose their page numbers (there are no pages),

--- a/spec/pdf_toc_spec.cr
+++ b/spec/pdf_toc_spec.cr
@@ -113,6 +113,18 @@ describe "Markd::Pdf.toc_html" do
     block.should_not contain("Nowhere")
   end
 
+  it "filters by the bottom of a level range" do
+    block = Markd::Pdf.toc_html(toc_entries, 2, "Contents", false, min_level: 2).should_not be_nil
+    block.should_not contain(">Alpha<") # level 1: below the window
+    block.should_not contain(">Beta<")  # level 1: below the window
+    block.should contain(">Alpha.1<")   # level 2: inside it
+    block.should_not contain("Nowhere") # page 0: still dropped
+  end
+
+  it "is nil when every heading falls outside the level range" do
+    Markd::Pdf.toc_html(toc_entries, 2, "Contents", false, min_level: 3).should be_nil
+  end
+
   it "omits page numbers in pageless mode" do
     block = Markd::Pdf.toc_html(toc_entries, 2, "Contents", true).should_not be_nil
     block.should contain("Alpha")
@@ -203,6 +215,43 @@ describe "markpdf two-pass TOC" do
     File.delete?(path)
   end
 
+  it "lists only the levels in a range, skipping a level-1 document title" do
+    pdftotext = pdftotext_path
+    pending!("pdftotext not available") unless pdftotext
+
+    chapters = 6
+    source = String.build do |io|
+      io << "# Titletoken\n\n"
+      1.upto(chapters) do |chapter|
+        io << "## Chaptertoken" << chapter << "\n\n"
+        io << "### Sectiontoken" << chapter << "\n\n"
+        3.times { |run| io << "Filler " << (chapter * 10 + run) << " " << ("prose " * 40).strip << "\n\n" }
+      end
+    end
+
+    path = temp_pdf_path
+    pages = Markd::Pdf.render(source, path, toc: true, toc_depth: 3, toc_min_level: 2)
+    texts = all_page_texts(pdftotext, path, pages)
+
+    toc_page = texts.index(&.includes?("Contents")).should_not be_nil
+    toc_text = texts[toc_page]
+    # The level-1 title stays out of the TOC...
+    toc_text.should_not contain("Titletoken")
+    # ...while every level-2 and level-3 heading makes it in with a
+    # true number.
+    1.upto(chapters) do |chapter|
+      ["Chaptertoken", "Sectiontoken"].each do |kind|
+        token = "#{kind}#{chapter}"
+        number = toc_text.scan(/#{token}\s+(\d+)/).first?.try(&.[1])
+        number.should_not be_nil, "no TOC entry for #{token}"
+        landing = pages_with_line(texts, token)
+        landing.size.should eq(1), "#{token} heading appears on pages #{landing}"
+        landing[0].to_s.should eq(number), "TOC says #{token} is on page #{number}, it renders on #{landing[0]}"
+      end
+    end
+    File.delete?(path)
+  end
+
   it "keeps numbers correct in kdp mode, where chapters open on recto pages" do
     pdftotext = pdftotext_path
     pending!("pdftotext not available") unless pdftotext
@@ -268,6 +317,35 @@ describe "markpdf CLI --toc" do
       output: IO::Memory.new, error: IO::Memory.new)
     result.success?.should be_false
     File.exists?(bad).should be_false
+    File.delete?(source)
+  end
+
+  it "takes a level range and rejects malformed ones" do
+    pending!("bin/markpdf not built") unless File.exists?(BIN_MARKPDF)
+
+    source = File.tempname("markpdf_spec_toc", ".md")
+    File.write(source, "# Titletoken\n\nprose\n\n## Alpha\n\nprose\n\n## Beta\n\nprose\n")
+    output = temp_pdf_path
+    status = Process.run(BIN_MARKPDF, [source, "--toc", "--toc-depth", "2-6", "-o", output],
+      error: Process::Redirect::Inherit).success?
+    status.should be_true
+
+    pdftotext = pdftotext_path
+    if pdftotext
+      first = page_text(pdftotext, output, 1)
+      first.should contain("Contents")
+      first.should contain("Alpha")
+      first.should_not contain("Titletoken")
+    end
+    File.delete?(output)
+
+    ["3-2", "0-2", "2-7", "2-", "soon"].each do |bad_depth|
+      bad = temp_pdf_path
+      result = Process.run(BIN_MARKPDF, [source, "--toc", "--toc-depth", bad_depth, "-o", bad],
+        output: IO::Memory.new, error: IO::Memory.new)
+      result.success?.should be_false, "--toc-depth #{bad_depth} should be rejected"
+      File.exists?(bad).should be_false
+    end
     File.delete?(source)
   end
 end

--- a/src/main_pdf.cr
+++ b/src/main_pdf.cr
@@ -65,8 +65,10 @@ doc = <<-DOC
                                every entry links to its section. The layout
                                runs repeatedly until the numbers stop moving
                                (a TOC's own length shifts the pages it points to)
-    --toc-depth <depth>        Deepest heading level the TOC lists, from
-                               1 (chapters only) to 6 [default: 1]
+    --toc-depth <depth>        Deepest heading level the TOC lists, or a
+                               range N-M listing only levels N through M
+                               (2-6 skips a level-1 document title);
+                               levels run 1 to 6 [default: 1]
     --toc-title <title>        Title above the table of contents [default: Contents]
     --config <path>            Read options from this YAML file instead of
                                ~/.config/markpdf/config.yml
@@ -142,29 +144,39 @@ end
 # The kdp gutter sizing, the TOC page numbers and the kdp warnings all
 # come from the library's settle loop; the CLI only picks where the
 # PDF lands and which code theme applies.
-def render_kdp(input, output, margin, options, style, theme, code_theme, page_size, mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate, language, toc, toc_depth, toc_title)
+def render_kdp(input, output, margin, options, style, theme, code_theme, page_size, mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate, language, toc, toc_depth, toc_min_level, toc_title)
   Markd::Pdf.render(input, output, options, page_size: page_size, base_dir: base_dir,
     header: header || "", footer: footer || "", theme: theme, html_input: html_input, style: style,
     pageless: pageless, hyphenate: hyphenate, language: language,
     code_theme: Markd::Pdf.pick_code_theme(code_theme, theme, style),
     margins: margin, kdp: true, mirror_headers: mirror_headers,
-    toc: toc, toc_depth: toc_depth, toc_title: toc_title)
+    toc: toc, toc_depth: toc_depth, toc_title: toc_title, toc_min_level: toc_min_level)
 end
 
 # Non-kdp TOC renders go through the same settle loop, against the
 # renderer the CLI already built (margins are fixed without the gutter
 # table, so one instance serves every pass).
-def render_toc(input, output, renderer, toc_depth, toc_title, pageless)
-  Markd::Pdf.settled_pages(true, toc_depth, toc_title, pageless, size_gutter: false) do |_, desired_toc|
+def render_toc(input, output, renderer, toc_depth, toc_min_level, toc_title, pageless)
+  Markd::Pdf.settled_pages(true, toc_depth, toc_title, pageless, size_gutter: false,
+    toc_min_level: toc_min_level) do |_, desired_toc|
     renderer.render_with_headings(input, output, desired_toc)
   end
 end
 
-# --toc-depth: an integer between 1 and 6, or the run stops here.
-def toc_depth_from(depth_string : String) : Int32
-  depth = depth_string.to_i?
-  return depth if depth && depth.in?(1..6)
-  abort_with("--toc-depth needs an integer between 1 and 6 (got '#{depth_string}')")
+record TocLevels, min : Int32, max : Int32
+
+# --toc-depth: a level N lists 1..N, a range N-M only levels N
+# through M, inclusive (so 2-2 is level 2 alone); both bounded by
+# 1..6, or the run stops here.
+def toc_levels_from(spec : String) : TocLevels
+  if match = spec.match(/\A(\d+)(?:-(\d+))?\z/)
+    low = match[1].to_i
+    high = match[2]?.try &.to_i
+    min = high ? low : 1
+    max = high || low
+    return TocLevels.new(min, max) if min.in?(1..6) && max.in?(1..6) && min <= max
+  end
+  abort_with("--toc-depth needs a level or level range between 1 and 6, like 2 or 2-6 (got '#{spec}')")
 end
 
 def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, header, footer, theme, code_theme, style, html_input, pageless, hyphenate, language, no_remote_images, kdp, mirror_headers, toc, toc_depth_string, toc_title)
@@ -173,7 +185,7 @@ def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, h
 
   Markd::Pdf.fetch_remote_images = !no_remote_images
 
-  toc_depth = toc_depth_from(toc_depth_string)
+  toc_levels = toc_levels_from(toc_depth_string)
 
   if kdp && font_paths.empty?
     STDERR.puts "markpdf: warning: no --font given; kdp mode embeds whatever system fonts cover the text. Pass --font to control the embedded typefaces."
@@ -202,9 +214,9 @@ def main(source, output, page_size, margin, css_paths, font_paths, emoji_font, h
     if kdp
       render_kdp(input, target, margin, options, style, theme, code_theme, page_size,
         mirror_headers, base_dir, header, footer, html_input, pageless, hyphenate,
-        language, toc, toc_depth, toc_title)
+        language, toc, toc_levels.max, toc_levels.min, toc_title)
     elsif toc
-      render_toc(input, target, renderer, toc_depth, toc_title, pageless)
+      render_toc(input, target, renderer, toc_levels.max, toc_levels.min, toc_title, pageless)
     else
       renderer.render(input, target)
     end

--- a/src/pdf.cr
+++ b/src/pdf.cr
@@ -287,16 +287,23 @@ module Markd
 
     # The one-time warning for a --toc that has nothing to list: either
     # the document has no headings, or none survive the depth filter.
-    private def self.warn_missing_toc(headings : Array(HeadingEntry), toc_depth : Int32) : Nil
+    private def self.warn_missing_toc(headings : Array(HeadingEntry), toc_min_level : Int32, toc_depth : Int32) : Nil
       if headings.empty?
         STDERR.puts "markpdf: warning: --toc found no headings; rendering without a table of contents"
       else
-        STDERR.puts "markpdf: warning: --toc found no headings at depth #{toc_depth}; rendering without a table of contents"
+        STDERR.puts "markpdf: warning: --toc found no headings at depth #{toc_depth_label(toc_min_level, toc_depth)}; rendering without a table of contents"
       end
     end
 
+    # How the TOC's level window reads in messages: a lone number when
+    # the window opens at 1 (plain --toc-depth N), N-M otherwise.
+    private def self.toc_depth_label(toc_min_level : Int32, toc_depth : Int32) : String
+      toc_min_level == 1 ? toc_depth.to_s : "#{toc_min_level}-#{toc_depth}"
+    end
+
     def self.settled_pages(toc : Bool, toc_depth : Int32, toc_title : String, pageless : Bool,
-                           size_gutter : Bool, &pass : Float64, String? -> {Int32, Array(HeadingEntry)}) : Int32
+                           size_gutter : Bool, toc_min_level : Int32 = 1,
+                           &pass : Float64, String? -> {Int32, Array(HeadingEntry)}) : Int32
       gutter = KDP_GUTTER_TABLE.first[2]
       desired_toc = nil.as(String?)
       warned_no_headings = false
@@ -304,9 +311,9 @@ module Markd
       settled = false
       MAX_TOC_PASSES.times do
         pages, headings = pass.call(size_gutter ? gutter : -1.0, desired_toc)
-        rebuilt = toc ? toc_html(headings, toc_depth, toc_title, pageless) : nil
+        rebuilt = toc ? toc_html(headings, toc_depth, toc_title, pageless, toc_min_level) : nil
         if toc && rebuilt.nil? && !warned_no_headings
-          warn_missing_toc(headings, toc_depth)
+          warn_missing_toc(headings, toc_min_level, toc_depth)
           warned_no_headings = true
         end
         needed_gutter = size_gutter ? kdp_gutter_mm(pages) : gutter
@@ -333,7 +340,8 @@ module Markd
     # pageless produces a single page as tall as the document (good
     # for on-screen viewing, wrong for printing); headers and footers
     # are ignored in that mode. toc prepends a two-pass table of
-    # contents listing headings down to toc_depth, each entry linking
+    # contents listing headings down to toc_depth — or only those
+    # between toc_min_level and toc_depth — each entry linking
     # to its section; see settled_pages for how the numbers settle.
     def self.render(source : String, output_path : String, options : Markd::Options = Markd::Options.new,
                     page_size : String = "a4", margin_mm : Float64 = 20.0, base_dir : String = ".",
@@ -342,14 +350,14 @@ module Markd
                     pageless : Bool = false, hyphenate : Bool = false, language : String = "en",
                     css : String? = nil, margins : String? = nil, kdp : Bool = false,
                     mirror_headers : Bool = false, toc : Bool = false, toc_depth : Int32 = 1,
-                    toc_title : String = "Contents") : Int32
+                    toc_title : String = "Contents", toc_min_level : Int32 = 1) : Int32
       if kdp && (margins.nil? || Pdf.parse_margins(margins).gutter < 0)
         # KDP mode with no explicit gutter: size the gutter from the
         # page count (Amazon's table). Page count depends on the
         # margins and — with a TOC — on the TOC block itself, so the
         # settle loop re-renders until both stop moving.
         parsed = parse_margins(margins || margin_mm.to_s)
-        pages = settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: true) do |gutter, desired_toc|
+        pages = settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: true, toc_min_level: toc_min_level) do |gutter, desired_toc|
           renderer = Renderer.new(options: options, style: style || "default", theme: theme,
             code_theme: code_theme, page_size: page_size, margins: margins_with_gutter(parsed, gutter),
             kdp: true, mirror_headers: mirror_headers, base_dir: base_dir, header: header,
@@ -371,7 +379,7 @@ module Markd
         html_input: html_input, pageless: pageless, hyphenate: hyphenate, language: language)
       renderer.add_css(css) if css
       if toc
-        settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: false) do |_, desired_toc|
+        settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: false, toc_min_level: toc_min_level) do |_, desired_toc|
           renderer.render_with_headings(source, output_path, desired_toc)
         end
       else
@@ -389,7 +397,7 @@ module Markd
                               pageless : Bool = false, hyphenate : Bool = false, language : String = "en",
                               css : String? = nil, margins : String? = nil, kdp : Bool = false,
                               mirror_headers : Bool = false, toc : Bool = false, toc_depth : Int32 = 1,
-                              toc_title : String = "Contents") : Bytes
+                              toc_title : String = "Contents", toc_min_level : Int32 = 1) : Bytes
       renderer = Renderer.new(options: options, style: style || "default", theme: theme, code_theme: code_theme,
         page_size: page_size, margin_mm: margin_mm, margins: margins, kdp: kdp,
         mirror_headers: mirror_headers, base_dir: base_dir, header: header, footer: footer,
@@ -399,7 +407,7 @@ module Markd
       # The settle loop only reports pages and headings, so the closure
       # keeps the last render's bytes aside for the final return.
       final_bytes = Bytes.new(0)
-      settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: false) do |_, desired_toc|
+      settled_pages(toc, toc_depth, toc_title, pageless, size_gutter: false, toc_min_level: toc_min_level) do |_, desired_toc|
         bytes, pages, headings = renderer.render_to_memory_with_headings(source, desired_toc)
         final_bytes = bytes
         {pages, headings}
@@ -492,12 +500,14 @@ module Markd
     # The TOC block injected ahead of the body: a title div —
     # deliberately not an <h1>, or it would self-list in the heading
     # map, trigger the kdp recto rule and land in the bookmarks — and
-    # one linked entry per heading at or above the depth filter.
-    # Entries whose heading fell on no page (page 0) are dropped, and
-    # pageless documents have no page numbers to show. Nil when no
-    # heading survives the filters: the caller renders without a TOC.
-    def self.toc_html(headings : Array(HeadingEntry), depth : Int32, title : String, pageless : Bool) : String?
-      entries = headings.reject { |heading| heading.level > depth || heading.page == 0 }
+    # one linked entry per heading inside the level window min_level
+    # to depth. Entries whose heading fell on no page (page 0) are
+    # dropped, and pageless documents have no page numbers to show.
+    # Nil when no heading survives the filters: the caller renders
+    # without a TOC.
+    def self.toc_html(headings : Array(HeadingEntry), depth : Int32, title : String, pageless : Bool,
+                      min_level : Int32 = 1) : String?
+      entries = headings.reject { |heading| heading.level < min_level || heading.level > depth || heading.page == 0 }
       return if entries.empty?
       lines = entries.map do |heading|
         page = pageless ? "" : %(<span class="toc-page">#{heading.page}</span>)


### PR DESCRIPTION
## What

`--toc-depth` now also accepts a range: `N` keeps its meaning (levels 1..N), while `N-M` lists only levels N through M, inclusive.

- `--toc --toc-depth 2-6` — everything except a level-1 document title: the usual markdown book (H1 = title, H2 = chapters) gets a real TOC by default shape instead of a single self-referential entry
- `--toc --toc-depth 2-2` — chapter titles alone
- `--toc --toc-depth 2-3` — chapters and their sections, title skipped

Validation is strict: integers 1..6, N ≤ M, and only the forms `N` or `N-M` (`3-2`, `2-7`, `0-2`, `2-`, `soon`, `2-2-2` all abort with a usage message on stderr). No silent clamping.

## Semantics

- The window filters **the TOC listing only** — PDF bookmarks/outline keep every heading (a top-level title bookmark is conventional and useful), and the `mtoc-N` anchor numbering stays aligned because the filter lives in `toc_html`, not in the heading map.
- The two-pass settle loop is untouched: it already rebuilds the TOC block each pass, and a smaller listing just settles like a smaller document.
- `warn_missing_toc` learned the range vocabulary: "--toc found no headings at depth 2-6" (lone `N` still reads "at depth N").

## Library

Additive kwarg `toc_min_level : Int32 = 1` on `Markd::Pdf.render` and `render_to_memory`; `settled_pages` takes it as a defaulted parameter before the block, so existing callers compile unchanged.

## Docs

Help text and the README docopt block were updated together and verified **byte-identical** to the actual `--help` output; the README TOC section documents the range form with the title-skip idiom.

## Verification

- 4 new specs in `spec/pdf_toc_spec.cr`: window filtering (including the "only level 2" case), nil when everything falls outside the window, a real two-pass render of a title+chapters+sections book at `toc_depth: 3, toc_min_level: 2` asserting the title stays out while every listed number matches the heading's true page, and a CLI spec covering `2-6` plus six rejected malformed values
- Full suite: 257 examples, 0 failures (1 pre-existing pending); ameba 0 failures; all four binaries build (fresh worktree: submodules + shim + shards build)
- Smoke-tested: `2-6` and `2-2` renders, `--print-config` dumping `toc_depth: 2-3`, config-file roundtrip (`toc-depth: 2-4` read back), kdp + range with recto numbering, both warning paths, and the usage errors above